### PR TITLE
logging and error management

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,6 @@ travis-ci = {repository = "wyyerd/pulsar-rs"}
 [dependencies]
 bytes = "0.4.0"
 crc = "1.0.0"
-failure = "0.1.0"
 futures = "0.1.23"
 nom = "4.0.0"
 prost = "0.4.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -33,6 +33,7 @@ serde_derive = "1.0"
 serde_json = "1.0.32"
 chrono = "0.4.6"
 futures-timer = "0.1.1"
+log = "0.4.6"
 
 [build-dependencies]
 prost-build = "0.4.0"

--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -67,7 +67,7 @@ impl<S: Stream<Item=Message, Error=Error>> Future for Receiver<S> {
 
     fn poll(&mut self) -> Result<Async<()>, ()> {
         match self.shutdown.poll() {
-            Ok(Async::Ready(())) | Err(_) => return Err(()),
+            Ok(Async::Ready(())) | Err(futures::Canceled) => return Err(()),
             Ok(Async::NotReady) => {}
         }
 

--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -5,6 +5,7 @@ use futures::{self, Async, Future, Stream, Sink, IntoFuture, future::{self, Eith
 use message::{proto::{self, command_subscribe::SubType}, Codec, Message};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
+use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
 use tokio::runtime::TaskExecutor;
@@ -16,7 +17,7 @@ pub enum Register {
     Consumer { consumer_id: u64, resolver: mpsc::UnboundedSender<Message> },
 }
 
-#[derive(Debug, PartialEq, Ord, PartialOrd, Eq)]
+#[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq)]
 pub enum RequestKey {
     RequestId(u64),
     ProducerSend { producer_id: u64, sequence_id: u64 },
@@ -305,14 +306,19 @@ impl ConnectionSender {
         self.send_message(msg, RequestKey::RequestId(request_id), |resp| resp.command.success)
     }
 
-    fn send_message<R, F>(&self, msg: Message, key: RequestKey, extract: F) -> impl Future<Item=R, Error=Error>
+    fn send_message<R: Debug, F>(&self, msg: Message, key: RequestKey, extract: F) -> impl Future<Item=R, Error=Error>
         where F: FnOnce(Message) -> Option<R>
     {
         let (resolver, response) = oneshot::channel();
+        trace!("sending message(key = {:?}): {:?}", key, msg);
 
+        let k = key.clone();
         let response = response
             .map_err(|oneshot::Canceled| Error::Disconnected)
-            .and_then(|message: Message| extract_message(message, extract));
+            .and_then(move |message: Message| {
+              trace!("received message(key = {:?}): {:?}", k, message);
+              extract_message(message, extract)
+            });
 
         match (self.registrations.unbounded_send(Register::Request { key, resolver, }), self.tx.unbounded_send(msg)) {
             (Ok(_), Ok(_)) => Either::A(response),
@@ -338,13 +344,18 @@ impl Connection {
                     .map_err(|e| e.into())
                     .map(|stream| tokio_codec::Framed::new(stream, Codec))
                     .and_then(|stream|
-                        stream.send(messages::connect(auth_data))
+                        stream.send({
+                          let msg =  messages::connect(auth_data);
+                          trace!("connection message: {:?}", msg);
+                          msg
+                        })
                             .and_then(|stream| stream.into_future().map_err(|(err, _)| err))
                             .and_then(move |(msg, stream)| match msg {
                                 Some(Message { command: proto::BaseCommand { error: Some(error), .. }, .. }) =>
                                     Err(Error::PulsarError(format!("{:?}", error))),
                                 Some(msg) => {
                                     let cmd = msg.command.clone();
+                                    trace!("received connection response: {:?}", msg);
                                     msg.command.connected
                                         .ok_or_else(|| Error::PulsarError(format!("Unexpected message from pulsar: {:?}", cmd)))
                                         .map(|_msg| stream)
@@ -417,7 +428,7 @@ impl Drop for Connection {
     }
 }
 
-fn extract_message<T, F>(message: Message, extract: F) -> Result<T, Error>
+fn extract_message<T: Debug, F>(message: Message, extract: F) -> Result<T, Error>
     where F: FnOnce(Message) -> Option<T>
 {
     if message.command.error.is_some() {
@@ -427,6 +438,7 @@ fn extract_message<T, F>(message: Message, extract: F) -> Result<T, Error>
     } else {
         let cmd = message.command.clone();
         if let Some(extracted) = extract(message) {
+            trace!("extracted message: {:?}", extracted);
             Ok(extracted)
         } else {
             Err(Error::UnexpectedResponse(format!("{:?}", cmd)))

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,7 +8,6 @@ extern crate serde;
 extern crate serde_json;
 extern crate tokio;
 extern crate tokio_codec;
-#[macro_use] extern crate failure;
 #[macro_use] extern crate futures;
 #[macro_use] extern crate nom;
 #[macro_use] extern crate prost_derive;
@@ -22,7 +21,7 @@ mod producer;
 mod error;
 mod connection;
 
-pub use error::Error;
+pub use error::{Error, ConsumerError, ProducerError};
 pub use connection::{Connection, Authentication};
 pub use producer::Producer;
 pub use consumer::{Consumer, ConsumerBuilder, Ack};
@@ -70,14 +69,14 @@ mod tests {
         produce.wait().unwrap();
 
         let mut consumed = 0;
-        let _ = consumer.for_each(move |data: Result<(TestData, Ack), Error>| {
+        let _ = consumer.for_each(move |data: Result<(TestData, Ack), ConsumerError>| {
             consumed += 1;
             match data {
                 Ok((_msg, ack)) => {
                     ack.ack();
                     if consumed >= 5000 {
                         println!("Finished consuming");
-                        Err(Error::Disconnected)
+                        Err(ConsumerError::Connection(Error::Disconnected))
                     } else {
                         Ok(())
                     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,6 +12,7 @@ extern crate tokio_codec;
 #[macro_use] extern crate futures;
 #[macro_use] extern crate nom;
 #[macro_use] extern crate prost_derive;
+#[macro_use] extern crate log;
 
 #[cfg(test)] #[macro_use] extern crate serde_derive;
 

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -95,6 +95,7 @@ impl Encoder for Codec {
             dst.reserve(buf.len());
         }
         dst.put_slice(&buf);
+        trace!("Encoder sending {} bytes", buf.len());
 //        println!("Wrote message {:?}", item);
         Ok(())
     }
@@ -105,6 +106,7 @@ impl Decoder for Codec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Message>, Error> {
+        trace!("Decoder received {} bytes", src.len());
         if src.len() >= 4 {
             let mut buf = Cursor::new(src);
             // `messageSize` refers only to _remaining_ message size, so we add 4 to get total frame size


### PR DESCRIPTION
this PR implements the following:
- add the log crate and a few `trace!` calls to see which messages were sent or received (which might be useful for debugging, but that we could remove if it's too heavy)
- rewrite the error management to remove the failure crate, and instead have the `Error` enum for connection errors, `ConsumerError` and `ProducerError` for more specific errors. They do not contain much yet, but I could modify their methods (like `subscribe()` for consumers) to give back context specific errors
So this is rather small for now, but will allow us to build upon it