### PR TITLE
make a wrapper error type

### DIFF
--- a/client/src/consumer.rs
+++ b/client/src/consumer.rs
@@ -1,5 +1,5 @@
 use crate::connection::{Connection, Authentication};
-use crate::error::{Error, ConsumerError};
+use crate::error::{ConnectionError, ConsumerError};
 use crate::message::{Message, Payload, proto::{self, command_subscribe::SubType}};
 use futures::Future;
 use futures::{Stream, sync::mpsc, Async};
@@ -100,7 +100,7 @@ impl<T> Stream for Consumer<T> {
             self.remaining_messages = self.batch_size;
         }
 
-        let message: Option<Option<(proto::CommandMessage, Payload)>> = try_ready!(self.messages.poll().map_err(|_| Error::Disconnected))
+        let message: Option<Option<(proto::CommandMessage, Payload)>> = try_ready!(self.messages.poll().map_err(|_| ConnectionError::Disconnected))
             .map(| Message { command, payload }: Message|
                 command.message
                     .and_then(move |msg| payload

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,7 +11,7 @@ mod producer;
 mod error;
 mod connection;
 
-pub use error::{Error, ConsumerError, ProducerError};
+pub use error::{Error, ConnectionError, ConsumerError, ProducerError};
 pub use connection::{Connection, Authentication};
 pub use producer::Producer;
 pub use consumer::{Consumer, ConsumerBuilder, Ack};
@@ -66,7 +66,7 @@ mod tests {
                     ack.ack();
                     if consumed >= 5000 {
                         println!("Finished consuming");
-                        Err(ConsumerError::Connection(Error::Disconnected))
+                        Err(ConsumerError::Connection(ConnectionError::Disconnected))
                     } else {
                         Ok(())
                     }

--- a/client/src/producer.rs
+++ b/client/src/producer.rs
@@ -1,5 +1,5 @@
 use crate::connection::{Connection, SerialId, Authentication};
-use crate::error::{Error, ProducerError};
+use crate::error::{ConnectionError, ProducerError};
 use crate::message::proto;
 use futures::{Future, future::{self, Either}};
 use rand;
@@ -39,7 +39,7 @@ impl Producer {
         self.connection.is_valid()
     }
 
-    pub fn check_connection(&self) -> impl Future<Item=(), Error=Error> {
+    pub fn check_connection(&self) -> impl Future<Item=(), Error=ConnectionError> {
         self.connection.sender().lookup_topic("test")
             .map(|_| ())
     }
@@ -89,7 +89,7 @@ impl Producer {
         &self.addr
     }
 
-    pub fn error(&mut self) -> Option<Error> {
+    pub fn error(&mut self) -> Option<ConnectionError> {
         self.connection.error()
     }
 }


### PR DESCRIPTION
this will allow using the `from_err` method in a future chain containing producers, consumers and service discovery, by converting each error kind to the more general `Error` type