### PR TITLE
extract the connection manager from service discovery

### DIFF
--- a/client/src/connection_manager.rs
+++ b/client/src/connection_manager.rs
@@ -1,0 +1,238 @@
+use crate::connection::{Authentication, Connection};
+use crate::error::ConnectionError;
+use futures::{
+    future::{self, Either},
+    sync::{mpsc, oneshot},
+    Future, Stream,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::runtime::TaskExecutor;
+
+/// holds connection information for a broker
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct BrokerAddress {
+    /// IP and port (using the proxy's if applicable)
+    pub address: SocketAddr,
+    /// pulsar URL for the broker
+    pub broker_url: String,
+    /// true if we're connecting through a proxy
+    pub proxy: bool,
+}
+
+/// Look up broker addresses for topics and partitioned topics
+///
+/// The ConnectionManager object provides a single interface to start
+/// interacting with a cluster. It will automatically follow redirects
+/// or use a proxy, and aggregate broker connections
+#[derive(Clone)]
+pub struct ConnectionManager {
+    tx: mpsc::UnboundedSender<Query>,
+    pub address: SocketAddr,
+}
+
+impl ConnectionManager {
+    pub fn new(
+        addr: SocketAddr,
+        auth: Option<Authentication>,
+        executor: TaskExecutor,
+    ) -> impl Future<Item = Self, Error = ConnectionError> {
+        Connection::new(addr.to_string(), auth.clone(), None, executor.clone())
+            .map_err(|e| e.into())
+            .and_then(move |conn| ConnectionManager::from_connection(conn, auth, addr, executor))
+    }
+
+    pub fn from_connection(
+        connection: Connection,
+        auth: Option<Authentication>,
+        address: SocketAddr,
+        executor: TaskExecutor,
+    ) -> Result<ConnectionManager, ConnectionError> {
+        let tx = engine(Arc::new(connection), auth, executor);
+        Ok(ConnectionManager { tx, address })
+    }
+
+    /// get an active Connection from a broker address
+    ///
+    /// creates a connection if not available
+    pub fn get_base_connection(
+        &self,
+    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self.tx.unbounded_send(Query::Base(tx)).is_err() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+
+    /// get an active Connection from a broker address
+    ///
+    /// creates a connection if not available
+    pub fn get_connection(
+        &self,
+        broker: &BrokerAddress,
+    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self
+            .tx
+            .unbounded_send(Query::Connect(broker.clone(), tx))
+            .is_err()
+        {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+
+    pub fn get_connection_from_url(
+        &self,
+        broker: Option<String>,
+    ) -> impl Future<Item = Option<(bool, Arc<Connection>)>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self.tx.unbounded_send(Query::Get(broker, tx)).is_err() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+}
+
+/// enum holding the service discovery query sent to the engine function
+enum Query {
+    Base(oneshot::Sender<Result<Arc<Connection>, ConnectionError>>),
+    /// broker URL
+    Get(
+        Option<String>,
+        oneshot::Sender<Result<Option<(bool, Arc<Connection>)>, ConnectionError>>,
+    ),
+    Connect(
+        BrokerAddress,
+        /// channel to send back the response
+        oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    ),
+    Connected(
+        BrokerAddress,
+        Connection,
+        /// channel to send back the response
+        oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    ),
+}
+
+/// core of the service discovery
+///
+/// this function loops over the query channel and launches lookups.
+/// It can send a message to itself for further queries if necessary.
+fn engine(
+    connection: Arc<Connection>,
+    auth: Option<Authentication>,
+    executor: TaskExecutor,
+) -> mpsc::UnboundedSender<Query> {
+    let (tx, rx) = mpsc::unbounded();
+    let mut connections: HashMap<BrokerAddress, Arc<Connection>> = HashMap::new();
+    let executor2 = executor.clone();
+    let tx2 = tx.clone();
+
+    let f = move || {
+        rx.for_each(move |query: Query| {
+            let exe = executor2.clone();
+            let self_tx = tx2.clone();
+
+            match query {
+                Query::Connect(broker, tx) => Either::A(match connections.get(&broker) {
+                    Some(conn) => {
+                        let _ = tx.send(Ok(conn.clone()));
+                        Either::A(future::ok(()))
+                    }
+                    None => Either::B(connect(broker, auth.clone(), tx, self_tx, exe)),
+                }),
+                Query::Base(tx) => {
+                    let _ = tx.send(Ok(connection.clone()));
+                    Either::B(future::ok(()))
+                }
+                Query::Connected(broker, conn, tx) => {
+                    let c = Arc::new(conn);
+                    connections.insert(broker, c.clone());
+                    let _ = tx.send(Ok(c));
+                    Either::B(future::ok(()))
+                }
+                Query::Get(url_opt, tx) => {
+                    let res = match url_opt {
+                        None => {
+                            debug!("using the base connection for lookup, not through a proxy");
+                            Some((false, connection.clone()))
+                        }
+                        Some(ref s) => {
+                            if let Some((b, c)) =
+                                connections.iter().find(|(k, _)| &k.broker_url == s)
+                            {
+                                debug!(
+                                    "using another connection for lookup, proxying to {:?}",
+                                    b.proxy
+                                );
+                                Some((b.proxy, c.clone()))
+                            } else {
+                                None
+                            }
+                        }
+                    };
+                    let _ = tx.send(Ok(res));
+                    Either::B(future::ok(()))
+                }
+            }
+        })
+        .map_err(|_| {
+            error!("service discovery engine stopped");
+            ()
+        })
+    };
+
+    executor.spawn(f());
+
+    tx
+}
+
+fn connect(
+    broker: BrokerAddress,
+    auth: Option<Authentication>,
+    tx: oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    self_tx: mpsc::UnboundedSender<Query>,
+    exe: TaskExecutor,
+) -> impl Future<Item = (), Error = ()> {
+    let proxy_url = if broker.proxy {
+        Some(broker.broker_url.clone())
+    } else {
+        None
+    };
+
+    Connection::new(broker.address.to_string(), auth, proxy_url, exe).then(move |res| {
+        match res {
+            Ok(conn) => match self_tx.unbounded_send(Query::Connected(broker, conn, tx)) {
+                Err(e) => match e.into_inner() {
+                    Query::Connected(_, _, tx) => {
+                        let _ = tx.send(Err(ConnectionError::Shutdown));
+                    }
+                    _ => {}
+                },
+                Ok(_) => {}
+            },
+            Err(e) => {
+                let _ = tx.send(Err(e));
+            }
+        };
+        future::ok(())
+    })
+}

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -66,6 +66,7 @@ pub enum ConnectionError {
     Encoding(String),
     SocketAddr(String),
     UnexpectedResponse(String),
+    Canceled,
     Shutdown,
 }
 
@@ -86,6 +87,7 @@ impl fmt::Display for ConnectionError {
       ConnectionError::Encoding(e) => write!(f, "Error encoding message: {}", e),
       ConnectionError::SocketAddr(e) => write!(f, "Error obtaning socket address: {}", e),
       ConnectionError::UnexpectedResponse(e) => write!(f, "Unexpected response from pulsar: {}", e),
+      ConnectionError::Canceled => write!(f, "canceled request"),
       ConnectionError::Shutdown => write!(f, "The connection was shut down"),
     }
   }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,10 +10,12 @@ mod consumer;
 mod producer;
 mod error;
 mod connection;
+mod connection_manager;
 mod service_discovery;
 
 pub use error::{Error, ConnectionError, ConsumerError, ProducerError, ServiceDiscoveryError};
 pub use connection::{Connection, Authentication};
+pub use connection_manager::ConnectionManager;
 pub use producer::Producer;
 pub use consumer::{Consumer, ConsumerBuilder, Ack};
 pub use service_discovery::ServiceDiscovery;


### PR DESCRIPTION
I got started on #20 and created a connection manager outside of the service discovery. It is designed the same way, a function that loops over queries coming from other futures. It gives access to connections either through the `BrokerAddress` information that comes from service discovery, or directly through a broker URL.
Maybe I should refactor the manager to only use broker URLs to index connections, but the interaction with proxys is not clear enough right now: lookups need to know if we have to go through a proxy or not, and the first connection is not proxying to a broker. I could add an argument to the manager's creation to indicate we expect to go through a proxy, that would simplify everything.

Now the example code I wrote in #1 looks like this:

```rust
    ConnectionManager::new(
        pulsar_addr.parse().unwrap(),
        Some(Authentication {
            name: auth_method_name.clone(),
            data: auth_data.clone(),
        }),
        runtime.executor(),
    )
    .from_err::<Error>()
    .and_then(|conn| {
        let manager = Arc::new(conn);
        ServiceDiscovery::with_manager(
            manager.clone(),
            runtime.executor(),
        ).into_future()
        .from_err()
        .and_then(|sd| {
            sd.lookup_partitioned_topic(topic)
                .from_err::<Error>()
                .map_err(|e| {
                    error!("topic lookup error: {:?}", e);
                    e
                })
        })
        .and_then(move |v| {
            info!("topic lookup result: {:?}", v);

            let res = v
                .iter()
                .cloned()
                .map(|(topic, broker_address)| {
                    manager
                        .get_connection(&broker_address)
                        .map_err(|e| {
                            error!("got error: {:?}", e);
                            e
                        })
                        .from_err()
                        .and_then(move |conn| {
                            Consumer::from_connection(
                                conn,
                                topic.to_string(),
                                "my_subscriber".to_string(),
                                SubType::Exclusive,
                                None,
                                None,
                                Box::new(|payload| deserialize(&payload.data)),
                                None,
                            )
                            .from_err()
                        })
                })
                .collect::<Vec<_>>();

            join_all(res)
        })
    })
    .and_then(|mut v| {
        info!("created {} consumers", v.len());

        let consumers = v
            .drain(..)
            .enumerate()
            .map(|(i, c)| {
                info!("will apply for_each on consumer {}", i);
                c.for_each(move |msg: Result<(Data, Ack), ConsumerError>| match msg {
                    Ok((data, ack)) => {
                        // process data
                        info!("consumer {} got data: {:?}", i, data);
                        ack.ack();
                        Ok(())
                    }
                    Err(e) => {
                        error!("consumer {} got an error: {:?}", i, e);
                        Ok(())
                        // return Err(_) to instead shutdown consumer
                    }
                })
            })
            .collect::<Vec<_>>();

        join_all(consumers).from_err().map(|val| {
            info!("consumers returned: {:?}", val);
        })
    })
    .map_err(|e| {
        error!("got error: {:?}", e);
        e
    })
    .wait()
    .unwrap();
```
