### PR TITLE
Client api implementation

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1,0 +1,217 @@
+use crate::connection::Authentication;
+use crate::connection_manager::{BrokerAddress, ConnectionManager};
+use crate::consumer::Consumer;
+use crate::error::{ConsumerError, Error};
+use crate::message::proto::{
+  command_subscribe::SubType, CommandSendReceipt};
+use crate::message::Payload;
+use crate::producer::Producer;
+use crate::service_discovery::ServiceDiscovery;
+use futures::{
+    future::{self, join_all, Either},
+    Future,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::runtime::TaskExecutor;
+
+/// Helper trait for consumer deserialization
+pub trait DeserializeMessage {
+    fn deserialize_message(payload: Payload) -> Result<Self, ConsumerError>
+    where
+        Self: std::marker::Sized;
+}
+
+pub struct Pulsar {
+    manager: Arc<ConnectionManager>,
+    service_discovery: Arc<ServiceDiscovery>,
+}
+
+impl Pulsar {
+    pub fn new(
+        addr: SocketAddr,
+        auth: Option<Authentication>,
+        executor: TaskExecutor,
+    ) -> impl Future<Item = Self, Error = Error> {
+        ConnectionManager::new(addr, auth.clone(), executor.clone())
+            .from_err()
+            .map(|manager| {
+                let manager = Arc::new(manager);
+                let service_discovery =
+                    Arc::new(ServiceDiscovery::with_manager(manager.clone(), executor));
+                Pulsar {
+                    manager,
+                    service_discovery,
+                }
+            })
+    }
+
+    pub fn lookup_topic<S: Into<String>>(
+        &self,
+        topic: S,
+    ) -> impl Future<Item = BrokerAddress, Error = Error> {
+        self.service_discovery.lookup_topic(topic).from_err()
+    }
+
+    /// get the number of partitions for a partitioned topic
+    pub fn lookup_partitioned_topic_number<S: Into<String>>(
+        &self,
+        topic: S,
+    ) -> impl Future<Item = u32, Error = Error> {
+        self.service_discovery
+            .lookup_partitioned_topic_number(topic)
+            .from_err()
+    }
+
+    pub fn lookup_partitioned_topic<S: Into<String>>(
+        &self,
+        topic: S,
+    ) -> impl Future<Item = Vec<(String, BrokerAddress)>, Error = Error> {
+        self.service_discovery
+            .lookup_partitioned_topic(topic)
+            .from_err()
+    }
+
+    pub fn create_consumer<T: DeserializeOwned, S1: Into<String> + Clone, S2: Into<String>>(
+        &self,
+        topic: S1,
+        subscription: S2,
+        sub_type: SubType,
+        deserialize: Box<dyn Fn(Payload) -> Result<T, ConsumerError> + Send>,
+    ) -> impl Future<Item = Consumer<T>, Error = Error> {
+        let manager = self.manager.clone();
+
+        self.service_discovery
+            .lookup_topic(topic.clone())
+            .from_err()
+            .and_then(move |broker_address| manager.get_connection(&broker_address).from_err())
+            .and_then(move |conn| {
+                Consumer::from_connection(
+                    conn,
+                    topic.into(),
+                    subscription.into(),
+                    sub_type,
+                    None,
+                    None,
+                    deserialize,
+                    None,
+                )
+                .from_err()
+            })
+    }
+
+    pub fn create_partitioned_consumers<
+        T: DeserializeOwned + DeserializeMessage + Sized,
+        S1: Into<String> + Clone,
+        S2: Into<String> + Clone,
+    >(
+        &self,
+        topic: S1,
+        subscription: S2,
+        sub_type: SubType,
+    ) -> impl Future<Item = Vec<Consumer<T>>, Error = Error> {
+        let manager = self.manager.clone();
+
+        self.service_discovery
+            .lookup_partitioned_topic(topic.clone())
+            .from_err()
+            .and_then(move |v| {
+                let res = v
+                    .iter()
+                    .cloned()
+                    .map(|(topic, broker_address)| {
+                        let subscription = subscription.clone();
+
+                        manager
+                            .get_connection(&broker_address)
+                            .from_err()
+                            .and_then(move |conn| {
+                                Consumer::from_connection(
+                                    conn,
+                                    topic.to_string(),
+                                    subscription.into(),
+                                    sub_type,
+                                    None,
+                                    None,
+                                    Box::new(|payload| T::deserialize_message(payload)),
+                                    None,
+                                )
+                                .from_err()
+                            })
+                    })
+                    .collect::<Vec<_>>();
+
+                join_all(res)
+            })
+    }
+
+    pub fn create_producer<S: Into<String> + Clone>(
+        &self,
+        topic: S,
+    ) -> impl Future<Item = Producer, Error = Error> {
+        let manager = self.manager.clone();
+
+        self.service_discovery
+            .lookup_topic(topic.clone())
+            .from_err()
+            .and_then(move |broker_address| manager.get_connection(&broker_address).from_err())
+            .map(move |conn| Producer::from_connection(conn, topic.into()))
+    }
+
+    pub fn create_partitioned_producers<S: Into<String> + Clone>(
+        &self,
+        topic: S,
+    ) -> impl Future<Item = Vec<Producer>, Error = Error> {
+        let manager = self.manager.clone();
+
+        self.service_discovery
+            .lookup_partitioned_topic(topic.clone())
+            .from_err()
+            .and_then(move |v| {
+
+                let res = v
+                    .iter()
+                    .cloned()
+                    .map(|(topic, broker_address)| {
+                        manager
+                            .get_connection(&broker_address)
+                            .from_err()
+                            .map(move |conn| Producer::from_connection(conn, topic.into()))
+                    })
+                    .collect::<Vec<_>>();
+
+                join_all(res)
+            })
+    }
+
+    pub fn send_raw<S: Into<String> + Clone>(
+        &self,
+        topic: S,
+        data: Vec<u8>,
+    ) -> impl Future<Item = CommandSendReceipt, Error = Error> {
+
+        let t = topic.clone();
+        self.create_producer(topic)
+            .and_then(|mut producer| {
+              producer.send_raw(t, data)
+                .from_err()
+            })
+    }
+
+    pub fn send_json<S: Into<String> + Clone, T: Serialize>(
+        &self,
+        topic: S,
+        msg: &T
+    ) -> impl Future<Item = CommandSendReceipt, Error = Error> {
+        let data = match serde_json::to_vec(msg) {
+          Ok(data) => data,
+          Err(e) => {
+            let e: ConsumerError = e.into();
+            return Either::A(future::failed(e.into()))
+          },
+        };
+
+        Either::B(self.send_raw(topic, data))
+    }
+}

--- a/client/src/connection_manager.rs
+++ b/client/src/connection_manager.rs
@@ -1,0 +1,238 @@
+use crate::connection::{Authentication, Connection};
+use crate::error::ConnectionError;
+use futures::{
+    future::{self, Either},
+    sync::{mpsc, oneshot},
+    Future, Stream,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::runtime::TaskExecutor;
+
+/// holds connection information for a broker
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct BrokerAddress {
+    /// IP and port (using the proxy's if applicable)
+    pub address: SocketAddr,
+    /// pulsar URL for the broker
+    pub broker_url: String,
+    /// true if we're connecting through a proxy
+    pub proxy: bool,
+}
+
+/// Look up broker addresses for topics and partitioned topics
+///
+/// The ConnectionManager object provides a single interface to start
+/// interacting with a cluster. It will automatically follow redirects
+/// or use a proxy, and aggregate broker connections
+#[derive(Clone)]
+pub struct ConnectionManager {
+    tx: mpsc::UnboundedSender<Query>,
+    pub address: SocketAddr,
+}
+
+impl ConnectionManager {
+    pub fn new(
+        addr: SocketAddr,
+        auth: Option<Authentication>,
+        executor: TaskExecutor,
+    ) -> impl Future<Item = Self, Error = ConnectionError> {
+        Connection::new(addr.to_string(), auth.clone(), None, executor.clone())
+            .map_err(|e| e.into())
+            .and_then(move |conn| ConnectionManager::from_connection(conn, auth, addr, executor))
+    }
+
+    pub fn from_connection(
+        connection: Connection,
+        auth: Option<Authentication>,
+        address: SocketAddr,
+        executor: TaskExecutor,
+    ) -> Result<ConnectionManager, ConnectionError> {
+        let tx = engine(Arc::new(connection), auth, executor);
+        Ok(ConnectionManager { tx, address })
+    }
+
+    /// get an active Connection from a broker address
+    ///
+    /// creates a connection if not available
+    pub fn get_base_connection(
+        &self,
+    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self.tx.unbounded_send(Query::Base(tx)).is_err() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+
+    /// get an active Connection from a broker address
+    ///
+    /// creates a connection if not available
+    pub fn get_connection(
+        &self,
+        broker: &BrokerAddress,
+    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self
+            .tx
+            .unbounded_send(Query::Connect(broker.clone(), tx))
+            .is_err()
+        {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+
+    pub fn get_connection_from_url(
+        &self,
+        broker: Option<String>,
+    ) -> impl Future<Item = Option<(bool, Arc<Connection>)>, Error = ConnectionError> {
+        if self.tx.is_closed() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        if self.tx.unbounded_send(Query::Get(broker, tx)).is_err() {
+            return Either::A(future::err(ConnectionError::Shutdown));
+        }
+
+        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+    }
+}
+
+/// enum holding the service discovery query sent to the engine function
+enum Query {
+    Base(oneshot::Sender<Result<Arc<Connection>, ConnectionError>>),
+    /// broker URL
+    Get(
+        Option<String>,
+        oneshot::Sender<Result<Option<(bool, Arc<Connection>)>, ConnectionError>>,
+    ),
+    Connect(
+        BrokerAddress,
+        /// channel to send back the response
+        oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    ),
+    Connected(
+        BrokerAddress,
+        Connection,
+        /// channel to send back the response
+        oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    ),
+}
+
+/// core of the service discovery
+///
+/// this function loops over the query channel and launches lookups.
+/// It can send a message to itself for further queries if necessary.
+fn engine(
+    connection: Arc<Connection>,
+    auth: Option<Authentication>,
+    executor: TaskExecutor,
+) -> mpsc::UnboundedSender<Query> {
+    let (tx, rx) = mpsc::unbounded();
+    let mut connections: HashMap<BrokerAddress, Arc<Connection>> = HashMap::new();
+    let executor2 = executor.clone();
+    let tx2 = tx.clone();
+
+    let f = move || {
+        rx.for_each(move |query: Query| {
+            let exe = executor2.clone();
+            let self_tx = tx2.clone();
+
+            match query {
+                Query::Connect(broker, tx) => Either::A(match connections.get(&broker) {
+                    Some(conn) => {
+                        let _ = tx.send(Ok(conn.clone()));
+                        Either::A(future::ok(()))
+                    }
+                    None => Either::B(connect(broker, auth.clone(), tx, self_tx, exe)),
+                }),
+                Query::Base(tx) => {
+                    let _ = tx.send(Ok(connection.clone()));
+                    Either::B(future::ok(()))
+                }
+                Query::Connected(broker, conn, tx) => {
+                    let c = Arc::new(conn);
+                    connections.insert(broker, c.clone());
+                    let _ = tx.send(Ok(c));
+                    Either::B(future::ok(()))
+                }
+                Query::Get(url_opt, tx) => {
+                    let res = match url_opt {
+                        None => {
+                            debug!("using the base connection for lookup, not through a proxy");
+                            Some((false, connection.clone()))
+                        }
+                        Some(ref s) => {
+                            if let Some((b, c)) =
+                                connections.iter().find(|(k, _)| &k.broker_url == s)
+                            {
+                                debug!(
+                                    "using another connection for lookup, proxying to {:?}",
+                                    b.proxy
+                                );
+                                Some((b.proxy, c.clone()))
+                            } else {
+                                None
+                            }
+                        }
+                    };
+                    let _ = tx.send(Ok(res));
+                    Either::B(future::ok(()))
+                }
+            }
+        })
+        .map_err(|_| {
+            error!("service discovery engine stopped");
+            ()
+        })
+    };
+
+    executor.spawn(f());
+
+    tx
+}
+
+fn connect(
+    broker: BrokerAddress,
+    auth: Option<Authentication>,
+    tx: oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
+    self_tx: mpsc::UnboundedSender<Query>,
+    exe: TaskExecutor,
+) -> impl Future<Item = (), Error = ()> {
+    let proxy_url = if broker.proxy {
+        Some(broker.broker_url.clone())
+    } else {
+        None
+    };
+
+    Connection::new(broker.address.to_string(), auth, proxy_url, exe).then(move |res| {
+        match res {
+            Ok(conn) => match self_tx.unbounded_send(Query::Connected(broker, conn, tx)) {
+                Err(e) => match e.into_inner() {
+                    Query::Connected(_, _, tx) => {
+                        let _ = tx.send(Err(ConnectionError::Shutdown));
+                    }
+                    _ => {}
+                },
+                Ok(_) => {}
+            },
+            Err(e) => {
+                let _ = tx.send(Err(e));
+            }
+        };
+        future::ok(())
+    })
+}

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -66,6 +66,7 @@ pub enum ConnectionError {
     Encoding(String),
     SocketAddr(String),
     UnexpectedResponse(String),
+    Canceled,
     Shutdown,
 }
 
@@ -86,6 +87,7 @@ impl fmt::Display for ConnectionError {
       ConnectionError::Encoding(e) => write!(f, "Error encoding message: {}", e),
       ConnectionError::SocketAddr(e) => write!(f, "Error obtaning socket address: {}", e),
       ConnectionError::UnexpectedResponse(e) => write!(f, "Unexpected response from pulsar: {}", e),
+      ConnectionError::Canceled => write!(f, "canceled request"),
       ConnectionError::Shutdown => write!(f, "The connection was shut down"),
     }
   }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,6 +12,7 @@ mod error;
 mod connection;
 mod connection_manager;
 mod service_discovery;
+mod client;
 
 pub use error::{Error, ConnectionError, ConsumerError, ProducerError, ServiceDiscoveryError};
 pub use connection::{Connection, Authentication};
@@ -19,6 +20,7 @@ pub use connection_manager::ConnectionManager;
 pub use producer::Producer;
 pub use consumer::{Consumer, ConsumerBuilder, Ack};
 pub use service_discovery::ServiceDiscovery;
+pub use client::{Pulsar, DeserializeMessage};
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,10 +10,12 @@ mod consumer;
 mod producer;
 mod error;
 mod connection;
+mod connection_manager;
 mod service_discovery;
 
 pub use error::{Error, ConnectionError, ConsumerError, ProducerError, ServiceDiscoveryError};
 pub use connection::{Connection, Authentication};
+pub use connection_manager::ConnectionManager;
 pub use producer::Producer;
 pub use consumer::{Consumer, ConsumerBuilder, Ack};
 pub use service_discovery::ServiceDiscovery;

--- a/client/src/service_discovery.rs
+++ b/client/src/service_discovery.rs
@@ -32,15 +32,15 @@ impl ServiceDiscovery {
     ) -> impl Future<Item = Self, Error = ServiceDiscoveryError> {
         ConnectionManager::new(addr, auth.clone(), executor.clone())
             .map_err(|e| e.into())
-            .and_then(move |conn| ServiceDiscovery::with_manager(Arc::new(conn), executor))
+            .map(move |conn| ServiceDiscovery::with_manager(Arc::new(conn), executor))
     }
 
     pub fn with_manager(
         manager: Arc<ConnectionManager>,
         executor: TaskExecutor,
-    ) -> Result<ServiceDiscovery, ServiceDiscoveryError> {
+    ) -> ServiceDiscovery {
         let tx = engine(manager, executor);
-        Ok(ServiceDiscovery { tx })
+        ServiceDiscovery { tx }
     }
 
     /// get the broker address for a topic


### PR DESCRIPTION
this is the other part for #20: a wrapper API that holds a connection manager and service discovery, can look up topics, create consumers and producers, and even send a single message to a topic in one function call.
Side note: I had an issue with the `create_partitioned_consumers`. It's not possible to share the deserialization closure as it is between all the consumers. So I found it easier to make the `DeserializeMessage` trait and require it on the output type. Maybe that's something that could be integrated into the consumers directly? With a blanket implementation for types that implement `serde::Deserialize`