### PR TITLE
Add support for batched messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ log = "0.4.6"
 trust-dns-resolver = "0.12"
 url = "2.1"
 regex = "1.1.7"
+bit-vec = "0.6"
 
 [dev-dependencies]
 serde = { version = "1.0.101", features = ["derive"] }


### PR DESCRIPTION
Closes #59 

Adds support for batched messages:
- Batched messages are properly separated and exposed as single messages
- `AckHandler` now tracks batched messages to ack/nack only once when either all messages are acked or one is nacked
