### PR TITLE
Futures 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio = "0.2"
 tokio-util = {version = "0.3", features = ["codec"] }
 rand = "0.7"
 chrono = "0.4.6"
-futures-timer = "0.1.1"
+futures-timer = "3.0"
 log = "0.4.6"
 trust-dns-resolver = "0.19"
 url = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 nom = "5.0.0"
 prost = "0.6.0"
 prost-derive = "0.6.0"
-tokio = "0.2"
+tokio = {version = "0.2", features = ["rt-threaded"]}
 tokio-util = {version = "0.3", features = ["codec"] }
 rand = "0.7"
 chrono = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,19 +19,19 @@ categories = ["api-bindings"]
 travis-ci = {repository = "wyyerd/pulsar-rs"}
 
 [dependencies]
-bytes = "0.4.0"
+bytes = "0.5.0"
 crc = "1.0.0"
-futures = "0.1.23"
+futures = "0.3"
 nom = "5.0.0"
-prost = "0.5.0"
-prost-derive = "0.5.0"
-tokio = "0.1.11"
-tokio-codec = "0.1.1"
+prost = "0.6.0"
+prost-derive = "0.6.0"
+tokio = "0.2"
+tokio-util = {version = "0.3", features = ["codec"] }
 rand = "0.7"
 chrono = "0.4.6"
 futures-timer = "0.1.1"
 log = "0.4.6"
-trust-dns-resolver = "0.12"
+trust-dns-resolver = "0.19"
 url = "2.1"
 regex = "1.1.7"
 bit-vec = "0.6"
@@ -41,4 +41,4 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
 
 [build-dependencies]
-prost-build = "0.5.0"
+prost-build = "0.6.0"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -84,7 +84,7 @@ impl<S: Stream<Item = Result<Message, ConnectionError>>> Receiver<S> {
 impl<S: Stream<Item = Result<Message, ConnectionError>>> Future for Receiver<S> {
     type Output = Result<(), ()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.shutdown.as_mut().poll(cx) {
             Poll::Ready(Ok(())) | Poll::Ready(Err(futures::channel::oneshot::Canceled)) => return Poll::Ready(Err(())),
             Poll::Pending => {}
@@ -202,7 +202,7 @@ impl<S: Sink<Message, Error = ConnectionError>> Sender<S> {
 impl<S: Sink<Message, Error = ConnectionError>> Future for Sender<S> {
     type Output = Result<(), ()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.shutdown.as_mut().poll(cx) {
             Poll::Ready(Ok(())) | Poll::Ready(Err(futures::channel::oneshot::Canceled)) => return Poll::Ready(Err(())),
             Poll::Pending => {}

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,10 +1,10 @@
 use crate::connection::{Authentication, Connection};
 use crate::error::ConnectionError;
-use crate::executor::{PulsarExecutor, TaskExecutor};
+use crate::executor::{Executor, TaskExecutor};
 use futures::{
-    future::{self, Either},
-    sync::{mpsc, oneshot},
-    Future, Stream,
+    future,
+    channel::{mpsc, oneshot},
+    Future, FutureExt, StreamExt,
 };
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -33,18 +33,17 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub fn new<E: PulsarExecutor>(
+    pub async fn new<E: Executor+'static>(
         addr: SocketAddr,
         auth: Option<Authentication>,
         executor: E,
-    ) -> impl Future<Item = Self, Error = ConnectionError> {
+    ) -> Result<Self, ConnectionError> {
         let executor = TaskExecutor::new(executor);
-        Connection::new(addr.to_string(), auth.clone(), None, executor.clone())
-            .map_err(|e| e)
-            .and_then(move |conn| ConnectionManager::from_connection(conn, auth, addr, executor))
+        let conn = Connection::new(addr.to_string(), auth.clone(), None, executor.clone()).await?;
+        ConnectionManager::from_connection(conn, auth, addr, executor)
     }
 
-    pub fn from_connection<E: PulsarExecutor>(
+    pub fn from_connection<E: Executor + 'static>(
         connection: Connection,
         auth: Option<Authentication>,
         address: SocketAddr,
@@ -58,30 +57,30 @@ impl ConnectionManager {
     /// get an active Connection from a broker address
     ///
     /// creates a connection if not available
-    pub fn get_base_connection(
+    pub async fn get_base_connection(
         &self,
-    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+    ) -> Result<Arc<Connection>, ConnectionError> {
         if self.tx.is_closed() {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
         let (tx, rx) = oneshot::channel();
         if self.tx.unbounded_send(Query::Base(tx)).is_err() {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
-        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+        rx.await.map_err(|_| ConnectionError::Canceled)?
     }
 
     /// get an active Connection from a broker address
     ///
     /// creates a connection if not available
-    pub fn get_connection(
+    pub async fn get_connection(
         &self,
         broker: &BrokerAddress,
-    ) -> impl Future<Item = Arc<Connection>, Error = ConnectionError> {
+    ) -> Result<Arc<Connection>, ConnectionError> {
         if self.tx.is_closed() {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
         let (tx, rx) = oneshot::channel();
@@ -90,26 +89,26 @@ impl ConnectionManager {
             .unbounded_send(Query::Connect(broker.clone(), tx))
             .is_err()
         {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
-        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+        rx.await.map_err(|_| ConnectionError::Canceled)?
     }
 
-    pub fn get_connection_from_url(
+    pub async fn get_connection_from_url(
         &self,
         broker: Option<String>,
-    ) -> impl Future<Item = Option<(bool, Arc<Connection>)>, Error = ConnectionError> {
+    ) -> Result<Option<(bool, Arc<Connection>)>, ConnectionError> {
         if self.tx.is_closed() {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
         let (tx, rx) = oneshot::channel();
         if self.tx.unbounded_send(Query::Get(broker, tx)).is_err() {
-            return Either::A(future::err(ConnectionError::Shutdown));
+            return Err(ConnectionError::Shutdown);
         }
 
-        Either::B(rx.map_err(|_| ConnectionError::Canceled).flatten())
+        rx.await.map_err(|_| ConnectionError::Canceled)?
     }
 }
 
@@ -148,28 +147,28 @@ fn engine(
     let executor2 = executor.clone();
     let tx2 = tx.clone();
 
-    let f = move || {
-        rx.for_each(move |query: Query| {
+    let f = async move {
+        while let Some(query) = rx.next().await {
             let exe = executor2.clone();
             let self_tx = tx2.clone();
 
             match query {
-                Query::Connect(broker, tx) => Either::A(match connections.get(&broker) {
+                Query::Connect(broker, tx) => match connections.get(&broker) {
                     Some(conn) => {
                         let _ = tx.send(Ok(conn.clone()));
-                        Either::A(future::ok(()))
+                        Ok(())
                     }
-                    None => Either::B(connect(broker, auth.clone(), tx, self_tx, exe)),
-                }),
+                    None => connect(broker, auth.clone(), tx, self_tx, exe).await,
+                },
                 Query::Base(tx) => {
                     let _ = tx.send(Ok(connection.clone()));
-                    Either::B(future::ok(()))
+                    Ok(())
                 }
                 Query::Connected(broker, conn, tx) => {
                     let c = Arc::new(conn);
                     connections.insert(broker, c.clone());
                     let _ = tx.send(Ok(c));
-                    Either::B(future::ok(()))
+                    Ok(())
                 }
                 Query::Get(url_opt, tx) => {
                     let res = match url_opt {
@@ -180,26 +179,25 @@ fn engine(
                         Some(ref s) => {
                             if let Some((b, c)) =
                                 connections.iter().find(|(k, _)| &k.broker_url == s)
-                            {
-                                debug!(
-                                    "using another connection for lookup, proxying to {:?}",
-                                    b.proxy
-                                );
-                                Some((b.proxy, c.clone()))
-                            } else {
-                                None
-                            }
+                                {
+                                    debug!(
+                                        "using another connection for lookup, proxying to {:?}",
+                                        b.proxy
+                                        );
+                                    Some((b.proxy, c.clone()))
+                                } else {
+                                    None
+                                }
                         }
                     };
                     let _ = tx.send(Ok(res));
-                    Either::B(future::ok(()))
+                    Ok(())
                 }
-            }
-        })
-        .map_err(|_| error!("service discovery engine stopped"))
+            }.expect("FIXME")
+        }
     };
 
-    executor.spawn(f());
+    executor.spawn(Box::pin(f));
 
     tx
 }
@@ -210,7 +208,7 @@ fn connect(
     tx: oneshot::Sender<Result<Arc<Connection>, ConnectionError>>,
     self_tx: mpsc::UnboundedSender<Query>,
     exe: TaskExecutor,
-) -> impl Future<Item = (), Error = ()> {
+) -> impl Future<Output = Result<(), ()>> {
     let proxy_url = if broker.proxy {
         Some(broker.broker_url.clone())
     } else {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -142,7 +142,7 @@ fn engine(
     auth: Option<Authentication>,
     executor: TaskExecutor,
 ) -> mpsc::UnboundedSender<Query> {
-    let (tx, rx) = mpsc::unbounded();
+    let (tx, mut rx) = mpsc::unbounded();
     let mut connections: HashMap<BrokerAddress, Arc<Connection>> = HashMap::new();
     let executor2 = executor.clone();
     let tx2 = tx.clone();

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1171,7 +1171,7 @@ mod tests {
     #[ignore]
     fn multi_consumer() {
         let addr = "127.0.0.1:6650".parse().unwrap();
-        let rt = Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
 
         let namespace = "public/default";
         let topic1 = "mt_test_a";
@@ -1251,7 +1251,7 @@ mod tests {
             assert!(latest_state.last_message_received.unwrap() >= send_start);
         };
 
-        rt.spawn(Box::pin(f));
+        rt.spawn(f);
 
         let start = Instant::now();
         loop {

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -3,18 +3,19 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::pin::Pin;
 
 use chrono::{DateTime, Utc};
-use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
-use futures::Future;
-use futures::{sync::mpsc, Async, Stream};
+use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures::{channel::mpsc, Future, FutureExt, Stream, StreamExt};
+use futures::future::{try_join_all};
+use futures::task::{Context, Poll};
 use rand;
 use regex::Regex;
-use tokio::timer::Interval;
 
 use crate::connection::{Authentication, Connection};
 use crate::error::{ConnectionError, ConsumerError, Error};
-use crate::executor::{PulsarExecutor, TaskExecutor};
+use crate::executor::{Executor, TaskExecutor};
 use crate::message::{
     parse_batched_message,
     proto::{self, command_subscribe::SubType, MessageIdData, Schema},
@@ -24,7 +25,6 @@ use crate::{DeserializeMessage, Pulsar};
 use bit_vec::BitVec;
 use nom::lib::std::cmp::Ordering;
 use nom::lib::std::collections::BinaryHeap;
-use tokio::prelude::Poll;
 
 #[derive(Clone, Default)]
 pub struct ConsumerOptions {
@@ -52,7 +52,7 @@ pub struct Consumer<T: DeserializeMessage> {
 }
 
 impl<T: DeserializeMessage> Consumer<T> {
-    pub fn new<E: PulsarExecutor>(
+    pub async fn new<E: Executor+'static>(
         addr: String,
         topic: String,
         subscription: String,
@@ -65,26 +65,24 @@ impl<T: DeserializeMessage> Consumer<T> {
         batch_size: Option<u32>,
         unacked_message_redelivery_delay: Option<Duration>,
         options: ConsumerOptions,
-    ) -> impl Future<Item = Consumer<T>, Error = Error> {
-        Connection::new(addr, auth_data, proxy_to_broker_url, executor)
-            .from_err()
-            .and_then(move |conn| {
-                Consumer::from_connection(
-                    Arc::new(conn),
-                    topic,
-                    subscription,
-                    sub_type,
-                    consumer_id,
-                    consumer_name,
-                    batch_size,
-                    unacked_message_redelivery_delay,
-                    options,
-                )
-            })
+    ) -> Result<Consumer<T>, Error> {
+        let conn = Connection::new(addr, auth_data, proxy_to_broker_url, executor)
+            .await?;
+        Consumer::from_connection(
+            Arc::new(conn),
+            topic,
+            subscription,
+            sub_type,
+            consumer_id,
+            consumer_name,
+            batch_size,
+            unacked_message_redelivery_delay,
+            options,
+            ).await
     }
 
-    pub fn from_connection(
-        conn: Arc<Connection>,
+    pub async fn from_connection(
+        connection: Arc<Connection>,
         topic: String,
         subscription: String,
         sub_type: SubType,
@@ -93,12 +91,12 @@ impl<T: DeserializeMessage> Consumer<T> {
         batch_size: Option<u32>,
         unacked_message_redelivery_delay: Option<Duration>,
         options: ConsumerOptions,
-    ) -> impl Future<Item = Consumer<T>, Error = Error> {
+    ) -> Result<Consumer<T>, Error> {
         let consumer_id = consumer_id.unwrap_or_else(rand::random);
         let (resolver, messages) = mpsc::unbounded();
         let batch_size = batch_size.unwrap_or(1000);
 
-        conn.sender()
+        let resp = connection.sender()
             .subscribe(
                 resolver,
                 topic.clone(),
@@ -107,37 +105,33 @@ impl<T: DeserializeMessage> Consumer<T> {
                 consumer_id,
                 consumer_name,
                 options.clone(),
-            )
-            .map(move |resp| (resp, conn))
-            .and_then(move |(_, conn)| {
-                conn.sender()
-                    .send_flow(consumer_id, batch_size)
-                    .map(move |()| conn)
-            })
-            .map_err(|e| Error::Consumer(ConsumerError::Connection(e)))
-            .map(move |connection| {
-                //TODO this should be shared among all consumers when using the client
-                //TODO make tick_delay configurable
-                let tick_delay = Duration::from_millis(500);
-                let ack_handler = AckHandler::new(
-                    connection.clone(),
-                    unacked_message_redelivery_delay,
-                    tick_delay,
-                    connection.executor(),
-                );
-                Consumer {
-                    connection,
-                    topic,
-                    id: consumer_id,
-                    messages,
-                    ack_handler,
-                    batch_size,
-                    remaining_messages: batch_size,
-                    data_type: PhantomData,
-                    options,
-                    current_message: None,
-                }
-            })
+            ).await;
+
+        connection.sender()
+            .send_flow(consumer_id, batch_size)
+            .map_err(|e| Error::Consumer(ConsumerError::Connection(e)))?;
+
+        //TODO this should be shared among all consumers when using the client
+        //TODO make tick_delay configurable
+        let tick_delay = Duration::from_millis(500);
+        let ack_handler = AckHandler::new(
+            connection.clone(),
+            unacked_message_redelivery_delay,
+            tick_delay,
+            connection.executor(),
+            );
+        Ok(Consumer {
+            connection,
+            topic,
+            id: consumer_id,
+            messages,
+            ack_handler,
+            batch_size,
+            remaining_messages: batch_size,
+            data_type: PhantomData,
+            options,
+            current_message: None,
+        })
     }
 
     pub fn topic(&self) -> &str {
@@ -167,18 +161,18 @@ impl<T: DeserializeMessage> Consumer<T> {
         }
     }
 
-    fn poll_current_message(&mut self) -> Poll<Option<Message<T::Output>>, Error> {
+    fn poll_current_message(&mut self) -> Poll<Result<Option<Message<T::Output>>, Error>> {
         if let Some(mut iterator) = self.current_message.take() {
             match iterator.next() {
                 Some((id, payload)) => {
                     self.current_message = Some(iterator);
                     let message = self.create_message(id, payload);
-                    Ok(Async::Ready(Some(message)))
+                    Poll::Ready(Ok(Some(message)))
                 }
-                None => Ok(Async::NotReady),
+                None => Poll::Pending,
             }
         } else {
-            Ok(Async::NotReady)
+            Poll::Pending
         }
     }
 }
@@ -310,16 +304,16 @@ impl Ord for MessageResend {
 struct AckHandler {
     pending_nacks: BinaryHeap<MessageResend>,
     conn: Arc<Connection>,
-    inbound: Option<UnboundedReceiver<AckMessage>>,
+    inbound: Option<Pin<Box<UnboundedReceiver<AckMessage>>>>,
     unack_redelivery_delay: Option<Duration>,
-    tick_timer: tokio::timer::Interval,
+    tick_timer: Pin<Box<tokio::time::Interval>>,
     batch_messages: BTreeMap<MessageIdData, (bool, BitVec)>,
 }
 
 impl AckHandler {
     /// Create and spawn a new AckHandler future, which will run until the connection fails, or all
     /// inbound senders are dropped and any pending redelivery messages have been sent
-    pub fn new<E: PulsarExecutor>(
+    pub fn new<E: Executor+'static>(
         conn: Arc<Connection>,
         redelivery_delay: Option<Duration>,
         tick_delay: Duration,
@@ -328,14 +322,14 @@ impl AckHandler {
         let (tx, rx) = mpsc::unbounded();
         let executor = TaskExecutor::new(executor);
 
-        executor.clone().spawn(AckHandler {
+        executor.clone().spawn(Box::pin(AckHandler {
             pending_nacks: BinaryHeap::new(),
             conn,
-            inbound: Some(rx),
+            inbound: Some(Box::pin(rx)),
             unack_redelivery_delay: redelivery_delay,
-            tick_timer: Interval::new_interval(tick_delay),
+            tick_timer: Box::pin(tokio::time::interval(tick_delay)),
             batch_messages: BTreeMap::new(),
-        });
+        }.map(|res| info!("FIXME: Ackhandker returned {:?}", res))));
         tx
     }
     fn next_ready_resend(&mut self) -> Option<MessageResend> {
@@ -346,12 +340,12 @@ impl AckHandler {
         }
         None
     }
-    fn next_inbound(&mut self) -> Option<AckMessage> {
+    fn next_inbound(&mut self, cx: &mut Context<'_>) -> Option<AckMessage> {
         if let Some(inbound) = &mut self.inbound {
-            match inbound.poll() {
-                Ok(Async::Ready(Some(msg))) => Some(msg),
-                Ok(Async::NotReady) => None,
-                Ok(Async::Ready(None)) | Err(_) => {
+            match inbound.as_mut().poll_next(cx) {
+                Poll::Ready(Some(msg)) => Some(msg),
+                Poll::Pending => None,
+                Poll::Ready(None) => {
                     self.inbound = None;
                     None
                 }
@@ -419,12 +413,11 @@ impl AckHandler {
 }
 
 impl Future for AckHandler {
-    type Item = ();
-    type Error = ();
+    type Output = Result<(), ()>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut acks: BTreeMap<(u64, bool), Vec<MessageIdData>> = BTreeMap::new();
-        while let Some(msg) = self.next_inbound() {
+        while let Some(msg) = self.next_inbound(cx) {
             match msg {
                 AckMessage::Ack {
                     consumer_id,
@@ -468,12 +461,12 @@ impl Future for AckHandler {
                 .sender()
                 .send_ack(consumer_id, message_ids, cumulative);
             if send_result.is_err() {
-                return Err(());
+                return Poll::Ready(Err(()));
             }
         }
         loop {
-            match self.tick_timer.poll() {
-                Ok(Async::Ready(Some(_))) => {
+            match self.tick_timer.as_mut().poll_next(cx) {
+                Poll::Ready(Some(_)) => {
                     let mut resends: BTreeMap<u64, Vec<MessageIdData>> = BTreeMap::new();
                     while let Some(ready) = self.next_ready_resend() {
                         resends
@@ -488,18 +481,18 @@ impl Future for AckHandler {
                             .sender()
                             .send_redeliver_unacknowleged_messages(consumer_id, message_ids);
                         if send_result.is_err() {
-                            return Err(());
+                            return Poll::Ready(Err(()));
                         }
                     }
                 }
-                Ok(Async::NotReady) => {
+                Poll::Pending => {
                     if self.inbound.is_none() && self.pending_nacks.is_empty() {
-                        return Ok(Async::Ready(()));
+                        return Poll::Ready(Ok(()));
                     } else {
-                        return Ok(Async::NotReady);
+                        return Poll::Pending;
                     }
                 }
-                Ok(Async::Ready(None)) | Err(_) => return Err(()),
+                Poll::Ready(None) => return Poll::Ready(Err(())),
             }
         }
     }
@@ -567,17 +560,16 @@ impl Iterator for BatchedMessageIterator {
 }
 
 impl<T: DeserializeMessage> Stream for Consumer<T> {
-    type Item = Message<T::Output>;
-    type Error = Error;
+    type Item = Result<Message<T::Output>, Error>;
 
-    fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
-        if let Ok(Async::Ready(message)) = self.poll_current_message() {
-            return Ok(Async::Ready(message));
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(Ok(Some(message))) = self.poll_current_message() {
+            return Poll::Ready(Some(Ok(message)));
         }
 
         if !self.connection.is_valid() {
             if let Some(err) = self.connection.error() {
-                return Err(Error::Consumer(ConsumerError::Connection(err)));
+                return Poll::Ready(Some(Err(Error::Consumer(ConsumerError::Connection(err)))));
             }
         }
 
@@ -588,15 +580,19 @@ impl<T: DeserializeMessage> Stream for Consumer<T> {
             self.remaining_messages = self.batch_size;
         }
 
-        let message: Option<Option<(proto::CommandMessage, Payload)>> = try_ready!(self
+        //FIXME
+        let message: Option<Option<(proto::CommandMessage, Payload)>> = match self
             .messages
-            .poll()
-            .map_err(|_| ConnectionError::Disconnected))
-        .map(|RawMessage { command, payload }| {
-            command
-                .message
-                .and_then(move |msg| payload.map(move |payload| (msg, payload)))
-        });
+            .poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => Some(None),
+                Poll::Ready(Some(RawMessage { command, payload })) => {
+                    Some(command
+                        .message
+                        .and_then(move |msg| payload.map(move |payload| (msg, payload))))
+                }
+            };
+            //.map_err(|_| ConnectionError::Disconnected)
 
         if message.is_some() {
             self.remaining_messages -= 1;
@@ -607,17 +603,23 @@ impl<T: DeserializeMessage> Stream for Consumer<T> {
                 Some(_) => {
                     self.current_message =
                         Some(BatchedMessageIterator::new(message.message_id, payload)?);
-                    self.poll_current_message()
+                    //FIXME
+                    //self.poll_current_message()
+                    if let Poll::Ready(Ok(Some(message))) = self.poll_current_message() {
+                        Poll::Ready(Some(Ok(message)))
+                    } else {
+                        Poll::Pending
+                    }
                 }
-                None => Ok(Async::Ready(Some(
-                    self.create_message(message.message_id, payload),
-                ))),
+                None => Poll::Ready(Some(
+                   Ok(self.create_message(message.message_id, payload)),
+                )),
             },
-            Some(None) => Err(Error::Consumer(ConsumerError::MissingPayload(format!(
+            Some(None) => Poll::Ready(Some(Err(Error::Consumer(ConsumerError::MissingPayload(format!(
                 "Missing payload for message {:?}",
                 message
-            )))),
-            None => Ok(Async::Ready(None)),
+            )))))),
+            None => Poll::Ready(None),
         }
     }
 }
@@ -838,7 +840,7 @@ impl<'a, Topic, Subscription, SubscriptionType>
 }
 
 impl<'a> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubType>> {
-    pub fn build<T: DeserializeMessage>(self) -> impl Future<Item = Consumer<T>, Error = Error> {
+    pub async fn build<T: DeserializeMessage>(self) -> Result<Consumer<T>, Error> {
         let ConsumerBuilder {
             pulsar,
             topic: Set(topic),
@@ -861,7 +863,7 @@ impl<'a> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubType>> {
             consumer_id,
             unacked_message_resend_delay,
             consumer_options.unwrap_or_else(ConsumerOptions::default),
-        )
+        ).await
     }
 }
 
@@ -919,8 +921,8 @@ pub struct MultiTopicConsumer<T: DeserializeMessage> {
     unacked_message_resend_delay: Option<Duration>,
     consumers: BTreeMap<String, Consumer<T>>,
     topics: VecDeque<String>,
-    new_consumers: Option<Box<dyn Future<Item = Vec<Consumer<T>>, Error = Error> + Send>>,
-    refresh: Box<dyn Stream<Item = (), Error = ()> + Send>,
+    new_consumers: Option<Pin<Box<dyn Future<Output = Result<Vec<Consumer<T>>, Error>> + Send>>>,
+    refresh: Pin<Box<dyn Stream<Item = ()> + Send>>,
     subscription: String,
     sub_type: SubType,
     options: ConsumerOptions,
@@ -952,10 +954,10 @@ impl<T: DeserializeMessage> MultiTopicConsumer<T> {
             consumers: BTreeMap::new(),
             topics: VecDeque::new(),
             new_consumers: None,
-            refresh: Box::new(
-                Interval::new(Instant::now(), topic_refresh)
+            refresh: Box::pin(
+                tokio::time::interval(topic_refresh)
                     .map(drop)
-                    .map_err(|e| panic!("error creating referesh timer: {}", e)),
+                    //.map_err(|e| panic!("error creating referesh timer: {}", e)),
             ),
             subscription: subscription.into(),
             sub_type,
@@ -966,7 +968,7 @@ impl<T: DeserializeMessage> MultiTopicConsumer<T> {
         }
     }
 
-    pub fn start_state_stream(&mut self) -> impl Stream<Item = ConsumerState, Error = ()> {
+    pub fn start_state_stream(&mut self) -> impl Stream<Item = ConsumerState> {
         let (tx, rx) = unbounded();
         self.state_streams.push(tx);
         rx
@@ -1026,19 +1028,18 @@ impl<T: DeserializeMessage> Debug for MultiTopicConsumer<T> {
 }
 
 impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
-    type Item = Message<T::Output>;
-    type Error = Error;
+    type Item = Result<Message<T::Output>, Error>;
 
-    fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(mut new_consumers) = self.new_consumers.take() {
-            match new_consumers.poll() {
-                Ok(Async::Ready(new_consumers)) => {
+            match new_consumers.poll_unpin(cx) {
+                Poll::Ready(Ok(new_consumers)) => {
                     self.add_consumers(new_consumers);
                 }
-                Ok(Async::NotReady) => {
+                Poll::Pending => {
                     self.new_consumers = Some(new_consumers);
                 }
-                Err(e) => {
+                Poll::Ready(Err(e)) => {
                     error!("Error creating pulsar consumers: {}", e);
                     // don't return error here; could be intermittent connection failure and we want
                     // to retry
@@ -1046,7 +1047,7 @@ impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
             }
         }
 
-        if let Ok(Async::Ready(_)) = self.refresh.poll() {
+        if let Poll::Ready(Some(_)) = self.refresh.poll_next_unpin(cx) {
             let regex = self.topic_regex.clone();
             let pulsar = self.pulsar.clone();
             let subscription = self.subscription.clone();
@@ -1055,38 +1056,35 @@ impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
             let options = self.options.clone();
             let unacked_message_resend_delay = self.unacked_message_resend_delay;
 
-            let new_consumers = Box::new(
-                self.pulsar
-                    .get_topics_of_namespace(self.namespace.clone(), proto::get_topics::Mode::All)
-                    .and_then(move |topics: Vec<String>| {
-                        trace!("fetched topics: {:?}", &topics);
-                        futures::future::collect(
-                            topics
-                                .into_iter()
-                                .filter(move |topic| {
-                                    !existing_topics.contains(topic)
-                                        && regex.is_match(topic.as_str())
-                                })
-                                .map(move |topic| {
-                                    trace!("creating consumer for topic {}", topic);
-                                    let pulsar = pulsar.clone();
-                                    let subscription = subscription.clone();
-                                    pulsar.create_consumer(
-                                        topic,
-                                        subscription,
-                                        sub_type,
-                                        None,
-                                        None,
-                                        None,
-                                        unacked_message_resend_delay,
-                                        options.clone(),
-                                    )
-                                }),
-                        )
-                    }),
-            );
+            let new_consumers = Box::pin(async {
+                let topics: Vec<String> = self.pulsar
+                    .get_topics_of_namespace(self.namespace.clone(), proto::get_topics::Mode::All).await?;
+                trace!("fetched topics: {:?}", &topics);
+
+                try_join_all(topics
+                             .into_iter()
+                             .filter(move |topic| {
+                                 !existing_topics.contains(topic)
+                                     && regex.is_match(topic.as_str())
+                             })
+                             .map(move |topic| {
+                                 trace!("creating consumer for topic {}", topic);
+                                 let pulsar = pulsar.clone();
+                                 let subscription = subscription.clone();
+                                 pulsar.create_consumer(
+                                     topic,
+                                     subscription,
+                                     sub_type,
+                                     None,
+                                     None,
+                                     None,
+                                     unacked_message_resend_delay,
+                                     options.clone(),
+                                     )
+                             })).await
+            });
             self.new_consumers = Some(new_consumers);
-            return self.poll();
+            return self.poll_next(cx);
         }
 
         let mut topics_to_remove = Vec::new();
@@ -1096,15 +1094,15 @@ impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
                 break;
             }
             let topic = self.topics.pop_front().unwrap();
-            if let Some(item) = self.consumers.get_mut(&topic).map(|c| c.poll()) {
+            if let Some(item) = self.consumers.get_mut(&topic).map(|c| c.poll_next_unpin(cx)) {
                 match item {
-                    Ok(Async::NotReady) => {}
-                    Ok(Async::Ready(Some(msg))) => result = Some(msg),
-                    Ok(Async::Ready(None)) => {
+                    Poll::Pending => {}
+                    Poll::Ready(Some(Ok(msg))) => result = Some(msg),
+                    Poll::Ready(None) => {
                         error!("Unexpected end of stream for pulsar topic {}", &topic);
                         topics_to_remove.push(topic.clone());
                     }
-                    Err(e) => {
+                    Poll::Ready(Some(Err(e))) => {
                         error!(
                             "Unexpected error consuming from pulsar topic {}: {}",
                             &topic, e
@@ -1120,10 +1118,10 @@ impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
         self.remove_consumers(&topics_to_remove);
         if let Some(result) = result {
             self.record_message();
-            return Ok(Async::Ready(Some(result)));
+            return Poll::Ready(Some(Ok(result)));
         }
 
-        Ok(Async::NotReady)
+        Poll::Pending
     }
 }
 

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1050,15 +1050,16 @@ impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
         if let Poll::Ready(Some(_)) = self.refresh.poll_next_unpin(cx) {
             let regex = self.topic_regex.clone();
             let pulsar = self.pulsar.clone();
+            let namespace = self.namespace.clone();
             let subscription = self.subscription.clone();
             let sub_type = self.sub_type;
             let existing_topics: BTreeSet<String> = self.consumers.keys().cloned().collect();
             let options = self.options.clone();
             let unacked_message_resend_delay = self.unacked_message_resend_delay;
 
-            let new_consumers = Box::pin(async {
-                let topics: Vec<String> = self.pulsar
-                    .get_topics_of_namespace(self.namespace.clone(), proto::get_topics::Mode::All).await?;
+            let new_consumers = Box::pin(async move {
+                let topics: Vec<String> = pulsar
+                    .get_topics_of_namespace(namespace.clone(), proto::get_topics::Mode::All).await?;
                 trace!("fetched topics: {:?}", &topics);
 
                 try_join_all(topics

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,30 +1,12 @@
-use futures::future::{/*ExecuteError, Executor,*/ Future, FutureExt};
+use futures::future::{Future, FutureExt};
 use std::sync::Arc;
 use std::pin::Pin;
 use std::ops::Deref;
 use tokio::runtime::Handle;
 
-/*
-trait Executor<F: Future<Output = Result<(), ()>>> {
-    fn execute(&self, future: Pin<Box<F>>) -> Result<(), ExecuteError<F>>;
-}
-
-struct ExecuteError<F> {
-    f: F,
-}
-*/
-pub trait Executor: /*std::fmt::Debug +*/ Send + Sync {
+pub trait Executor: Send + Sync {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
 }
-
-
-/*
-pub trait PulsarExecutor: Executor<BoxSendFuture> + Send + Sync + 'static {}
-
-impl<T: Executor<BoxSendFuture> + Send + Sync + 'static> PulsarExecutor for T {}
-
-type BoxSendFuture = Box<dyn Future<Output = Result<(), ()>> + Send + 'static>;
-*/
 
 #[derive(Clone)]
 pub struct TaskExecutor {
@@ -50,19 +32,9 @@ impl TaskExecutor {
             Err(_) => panic!("no executor available"),
         }
     }
-    /*pub fn spawn<F>(&self, f: F)
-    where
-        F: Future<Output = Result<(), ()>> + Send + 'static,
-    {
-        if self.execute(f).is_err() {
-            panic!("no executor available")
-        }
-    }*/
 }
 
 impl Executor for TaskExecutor
-// where
-//    F: Future<Output = Result<(), ()>> + Send + 'static,
 {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         self.inner.deref().spawn(f)

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2,6 +2,7 @@ use futures::future::{/*ExecuteError, Executor,*/ Future, FutureExt};
 use std::sync::Arc;
 use std::pin::Pin;
 use std::ops::Deref;
+use tokio::runtime::Handle;
 
 /*
 trait Executor<F: Future<Output = Result<(), ()>>> {
@@ -65,5 +66,15 @@ impl Executor for TaskExecutor
 {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         self.inner.deref().spawn(f)
+    }
+}
+
+#[derive(Clone,Debug)]
+pub struct TokioExecutor(pub Handle);
+
+impl Executor for TokioExecutor {
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
+        self.0.spawn(f);
+        Ok(())
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,44 +1,69 @@
-use futures::future::{ExecuteError, Executor, Future};
+use futures::future::{/*ExecuteError, Executor,*/ Future, FutureExt};
 use std::sync::Arc;
+use std::pin::Pin;
+use std::ops::Deref;
 
+/*
+trait Executor<F: Future<Output = Result<(), ()>>> {
+    fn execute(&self, future: Pin<Box<F>>) -> Result<(), ExecuteError<F>>;
+}
+
+struct ExecuteError<F> {
+    f: F,
+}
+*/
+pub trait Executor: /*std::fmt::Debug +*/ Send + Sync {
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
+}
+
+
+/*
 pub trait PulsarExecutor: Executor<BoxSendFuture> + Send + Sync + 'static {}
 
 impl<T: Executor<BoxSendFuture> + Send + Sync + 'static> PulsarExecutor for T {}
 
-type BoxSendFuture = Box<dyn Future<Item = (), Error = ()> + Send + 'static>;
+type BoxSendFuture = Box<dyn Future<Output = Result<(), ()>> + Send + 'static>;
+*/
 
 #[derive(Clone)]
 pub struct TaskExecutor {
-    inner: Arc<dyn Executor<BoxSendFuture> + Send + Sync + 'static>,
+    inner: Arc<dyn Executor + Send + Sync + 'static>,
 }
 
 impl TaskExecutor {
     pub fn new<E>(exec: E) -> Self
     where
-        E: PulsarExecutor,
+        E: Executor + 'static,
     {
         Self {
             inner: Arc::new(exec),
         }
     }
-    pub fn spawn<F>(&self, f: F)
+
+    fn execute<F>(&self, f: F) -> Result<(), ()>
+        where
+            F: Future<Output = Result<(), ()>> + Send + 'static,
+    {
+        match self.inner.spawn(Box::pin(f.map(|_| ()))) {
+            Ok(()) => Ok(()),
+            Err(_) => panic!("no executor available"),
+        }
+    }
+    /*pub fn spawn<F>(&self, f: F)
     where
-        F: Future<Item = (), Error = ()> + Send + 'static,
+        F: Future<Output = Result<(), ()>> + Send + 'static,
     {
         if self.execute(f).is_err() {
             panic!("no executor available")
         }
-    }
+    }*/
 }
 
-impl<F> Executor<F> for TaskExecutor
-where
-    F: Future<Item = (), Error = ()> + Send + 'static,
+impl Executor for TaskExecutor
+// where
+//    F: Future<Output = Result<(), ()>> + Send + 'static,
 {
-    fn execute(&self, f: F) -> Result<(), ExecuteError<F>> {
-        match self.inner.execute(Box::new(f)) {
-            Ok(()) => Ok(()),
-            Err(_) => panic!("no executor available"),
-        }
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
+        self.inner.deref().spawn(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ mod service_discovery;
 mod tests {
     use std::time::{Duration, Instant};
 
-    use futures::{future, Future, Stream};
-    use futures_timer::ext::FutureExt;
+    use futures::{future, Future, Stream, StreamExt, TryStreamExt};
     use tokio;
+    use tokio::runtime::Runtime;
 
     use message::proto::command_subscribe::SubType;
 
@@ -56,6 +56,7 @@ mod tests {
     use crate::consumer::Message;
     use crate::message::Payload;
     use crate::Error as PulsarError;
+    use crate::executor::TokioExecutor;
 
     use super::*;
     use nom::lib::std::collections::BTreeSet;
@@ -135,203 +136,187 @@ mod tests {
     #[test]
     #[ignore]
     fn round_trip() {
-        let addr = "127.0.0.1:6650".parse().unwrap();
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = Runtime::new().unwrap();
 
-        let pulsar: Pulsar = Pulsar::new(addr, None, runtime.executor()).wait().unwrap();
+        let f = async {
+            let addr = "127.0.0.1:6650".parse().unwrap();
+            let executor = TokioExecutor(tokio::runtime::Handle::current());
+            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let producer = pulsar.producer(None);
 
-        let producer = pulsar.producer(None);
+            for i in 0u16..5000 {
+                producer.send(
+                    "test",
+                    &TestData {
+                        data: "data".to_string(),
+                    },
+                ).await.unwrap();
+            }
 
-        future::join_all((0..5000).map(|_| {
-            producer.send(
-                "test",
-                &TestData {
-                    data: "data".to_string(),
-                },
-            )
-        }))
-        .map_err(|e| Error::from(e))
-        .timeout(Duration::from_secs(5))
-        .wait()
-        .unwrap();
+            let consumer: Consumer<TestData> = pulsar
+                .consumer()
+                .with_topic("test")
+                .with_consumer_name("test_consumer")
+                .with_subscription_type(SubType::Exclusive)
+                .with_subscription("test_subscription")
+                .build()
+                .await
+                .unwrap();
 
-        let consumer: Consumer<TestData> = pulsar
-            .consumer()
-            .with_topic("test")
-            .with_consumer_name("test_consumer")
-            .with_subscription_type(SubType::Exclusive)
-            .with_subscription("test_subscription")
-            .build()
-            .wait()
-            .unwrap();
-
-        consumer
-            .take(5000)
-            .map_err(|e| e.into())
-            .for_each(move |Message { payload, ack, .. }| {
-                ack.ack();
-                let data = payload?;
-                if data.data.as_str() == "data" {
-                    Ok(())
-                } else {
-                    Err(Error::Message(format!(
-                        "Unexpected payload: {}",
-                        &data.data
-                    )))
+            let mut stream = consumer.take(5000);
+            while let Some(res) = stream.next().await {
+                    let Message { payload, ack, .. } = res.unwrap();
+                    ack.ack();
+                    let data = payload.unwrap();
+                    if data.data.as_str() != "data" {
+                        panic!("Unexpected payload: {}", &data.data);
+                    }
                 }
-            })
-            .timeout(Duration::from_secs(5))
-            .wait()
-            .unwrap();
+            // FIXME .timeout(Duration::from_secs(5))
+        };
+
+        runtime.spawn(Box::pin(f));
     }
 
     #[test]
     #[ignore]
     fn unsized_data() {
-        let addr = "127.0.0.1:6650".parse().unwrap();
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let pulsar: Pulsar = Pulsar::new(addr, None, runtime.executor()).wait().unwrap();
-        let producer = pulsar.producer(None);
+        let runtime = Runtime::new().unwrap();
 
-        // test &str
-        {
-            let topic = "test_unsized_data_str";
-            let send_data = "some unsized data";
+        let f = async {
+            let executor = TokioExecutor(tokio::runtime::Handle::current());
+            let addr = "127.0.0.1:6650".parse().unwrap();
+            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let producer = pulsar.producer(None);
 
-            let consumer = pulsar
-                .consumer()
-                .with_topic(topic)
-                .with_subscription_type(SubType::Exclusive)
-                .with_subscription("test_subscription")
-                .build::<String>()
-                .wait()
-                .unwrap();
+            // test &str
+            {
+                let topic = "test_unsized_data_str";
+                let send_data = "some unsized data";
 
-            producer.send(topic, send_data).wait().unwrap();
+                let consumer = pulsar
+                    .consumer()
+                    .with_topic(topic)
+                    .with_subscription_type(SubType::Exclusive)
+                    .with_subscription("test_subscription")
+                    .build::<String>()
+                    .await
+                    .unwrap();
 
-            consumer
-                .take(1)
-                .map_err(|e| e.into())
-                .for_each(move |Message { payload, ack, .. }| {
+                producer.send(topic, send_data).await.unwrap();
+
+                let mut stream = consumer.take(1);
+                while let Some(res) = stream.next().await {
+
+                    let Message { payload, ack, .. } = res.unwrap();
+
                     ack.ack();
-                    let data = payload?;
-                    if data.as_str() == send_data {
-                        Ok(())
-                    } else {
-                        Err(Error::Message(format!(
-                            "Unexpected payload in &str test: {}",
-                            &data
-                        )))
+                    let data = payload.unwrap();
+                    if data.as_str() != send_data {
+                        panic!("Unexpected payload in &str test: {}", &data);
                     }
-                })
-                .timeout(Duration::from_secs(1))
-                .wait()
-                .unwrap();
-        }
+                }
+                //FIXME .timeout(Duration::from_secs(1))
+            }
 
-        // test &[u8]
-        {
-            let topic = "test_unsized_data_bytes";
-            let send_data: &[u8] = &[0, 1, 2, 3];
+            // test &[u8]
+            {
+                let topic = "test_unsized_data_bytes";
+                let send_data: &[u8] = &[0, 1, 2, 3];
 
-            let consumer = pulsar
-                .consumer()
-                .with_topic(topic)
-                .with_subscription_type(SubType::Exclusive)
-                .with_subscription("test_subscription")
-                .build::<Vec<u8>>()
-                .wait()
-                .unwrap();
+                let consumer = pulsar
+                    .consumer()
+                    .with_topic(topic)
+                    .with_subscription_type(SubType::Exclusive)
+                    .with_subscription("test_subscription")
+                    .build::<Vec<u8>>()
+                    .await
+                    .unwrap();
 
-            producer.send(topic, send_data).wait().unwrap();
+                producer.send(topic, send_data).await.unwrap();
 
-            consumer
-                .take(1)
-                .map_err(|e| e.into())
-                .for_each(move |Message { payload, ack, .. }| {
-                    ack.ack();
-                    let data = payload;
-                    if data.as_slice() == send_data {
-                        Ok(())
-                    } else {
-                        Err(Error::Message(format!(
-                            "Unexpected payload in &[u8] test: {:?}",
-                            &data
-                        )))
+
+                let mut stream = consumer.take(1);
+                while let Some(res) = stream.next().await {
+                        let Message { payload, ack, .. } = res.unwrap();
+                        ack.ack();
+                        let data = payload;
+                        if data.as_slice() != send_data {
+                            panic!("Unexpected payload in &[u8] test: {:?}", &data);
+                        }
                     }
-                })
-                .timeout(Duration::from_secs(1))
-                .wait()
-                .unwrap();
-        }
+                //FIXME .timeout(Duration::from_secs(1))
+            }
+        };
+
+        runtime.spawn(Box::pin(f));
     }
 
     #[test]
     #[ignore]
     fn redelivery() {
+        let runtime = Runtime::new().unwrap();
+
         let addr = "127.0.0.1:6650".parse().unwrap();
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
-        let pulsar: Pulsar = Pulsar::new(addr, None, runtime.executor()).wait().unwrap();
-
-        let producer = pulsar.producer(None);
-
-        let topic: String = std::iter::repeat(())
-            .map(|()| rand::thread_rng().sample(Alphanumeric))
-            .take(7)
-            .collect();
-
-        let resend_delay = Duration::from_secs(4);
-
-        let consumer: Consumer<TestData> = pulsar
-            .consumer()
-            .with_topic(&topic)
-            .with_consumer_name("test_consumer")
-            .with_subscription_type(SubType::Exclusive)
-            .with_subscription("test_subscription")
-            .with_unacked_message_resend_delay(Some(resend_delay))
-            .build()
-            .wait()
-            .unwrap();
-
-        let message_count = 10;
-
-        future::join_all((0..message_count).map(|i| {
-            producer.send(
-                topic.clone(),
-                &TestData {
-                    data: i.to_string(),
-                },
-            )
-        }))
-        .map_err(|e| Error::from(e))
-        .timeout(Duration::from_secs(5))
-        .wait()
-        .unwrap();
-
         let (tx, rx) = std::sync::mpsc::channel();
 
         let mut seen = BTreeSet::new();
         let start = Instant::now();
-        runtime.executor().spawn(
-            consumer
-                .take(message_count * 2)
-                .map_err(|e| Error::from(e))
-                .for_each(move |Message { payload, ack, .. }| {
-                    let data = payload?;
-                    tx.send(data.data.clone()).unwrap();
-                    if !seen.contains(&data.data) {
-                        seen.insert(data.data);
-                    } else {
-                        //ack the second time around
-                        ack.ack();
-                    }
-                    Ok(())
-                    // no ack
-                })
-                .timeout(Duration::from_secs(15))
-                .map_err(|e| panic!("{}", e)),
-        );
+        let resend_delay = Duration::from_secs(4);
+
+        let message_count = 10;
+        let f = async move {
+            let executor = TokioExecutor(tokio::runtime::Handle::current());
+            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+
+            let producer = pulsar.producer(None);
+
+            let topic: String = std::iter::repeat(())
+                .map(|()| rand::thread_rng().sample(Alphanumeric))
+                .take(7)
+                .collect();
+
+            let consumer: Consumer<TestData> = pulsar
+                .consumer()
+                .with_topic(&topic)
+                .with_consumer_name("test_consumer")
+                .with_subscription_type(SubType::Exclusive)
+                .with_subscription("test_subscription")
+                .with_unacked_message_resend_delay(Some(resend_delay))
+                .build()
+                .await
+                .unwrap();
+
+
+            for i in 0u8..message_count {
+                producer.send(
+                    topic.clone(),
+                    &TestData {
+                        data: i.to_string(),
+                    },
+                    ).await.unwrap();
+            }
+
+            let mut stream = consumer
+                .take(message_count as usize * 2)
+                .map_err(|e| Error::from(e));
+            while let Some(res) = stream.next().await {
+
+                let Message { payload, ack, .. } = res.unwrap();
+                let data = payload.unwrap();
+                tx.send(data.data.clone()).unwrap();
+                if !seen.contains(&data.data) {
+                    seen.insert(data.data);
+                } else {
+                    //ack the second time around
+                    ack.ack();
+                }
+            }
+                //FIXME .timeout(Duration::from_secs(15))
+        };
+
+
+        runtime.spawn(Box::pin(f));
 
         let mut counts = BTreeMap::new();
 
@@ -349,6 +334,7 @@ mod tests {
                 panic!("timed out waiting for messages to be read");
             }
         }
+
         //check all messages we received are correct
         (0..message_count).for_each(|i| {
             let count = counts.get(&i.to_string());
@@ -362,6 +348,7 @@ mod tests {
             }
         });
         let mut redelivery_start = None;
+
         let timeout = Instant::now() + resend_delay + Duration::from_secs(4);
         while read_count < 2 * message_count {
             if let Ok(data) = rx.try_recv() {
@@ -388,7 +375,7 @@ mod tests {
         );
         assert!(redelivery_start > expected_redelivery_start - Duration::from_secs(1));
         assert!(redelivery_start < expected_redelivery_start + Duration::from_secs(1));
-        (0..message_count).for_each(|i| {
+        (0u8..message_count).for_each(|i| {
             let count = counts.get(&i.to_string());
             if count != Some(&2) {
                 println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,19 @@ pub use consumer::{
     Ack, Consumer, ConsumerBuilder, ConsumerOptions, ConsumerState, Message, MultiTopicConsumer,
 };
 pub use error::{ConnectionError, ConsumerError, Error, ProducerError, ServiceDiscoveryError};
-pub use executor::{PulsarExecutor, TaskExecutor};
+pub use executor::{Executor, TaskExecutor};
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};
 pub use service_discovery::ServiceDiscovery;
+
+macro_rules! try_ready {
+    ($e:expr) => (match $e {
+        $crate::futures::task::Poll::Ready(Ok(t)) => t,
+        $crate::futures::task::Poll::Pending => return $crate::futures::task::Poll::Pending,
+        $crate::futures::task::Poll::Ready(Err(e)) => return $crate::futures::task::Poll::Ready(Err(From::from(e))),
+    })
+}
 
 mod client;
 mod connection;

--- a/src/message.rs
+++ b/src/message.rs
@@ -113,7 +113,7 @@ impl Encoder<Message> for Codec {
             buf.put(&payload.data[..]);
 
             let crc = crc32::checksum_castagnoli(&buf[metdata_offset..]);
-            let crc_buf: &mut [u8] = &mut buf[crc_offset..metdata_offset];
+            let mut crc_buf: &mut [u8] = &mut buf[crc_offset..metdata_offset];
             crc_buf.put_u32(crc);
         }
         if dst.remaining_mut() < buf.len() {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -202,7 +202,9 @@ impl Future for ProducerEngine {
                             let f = async move {
                                 p
                                     .send_message(message, None)
-                                    .map(|r| resolver.send(r).expect("FIXME"));//.map_err(drop)),
+                                    .map(|r| {
+                                        resolver.send(r).expect("FIXME")
+                                    }).await;//.map_err(drop)),
                             };
                             self.pulsar.executor().spawn(Box::pin(f));
                         }
@@ -219,7 +221,9 @@ impl Future for ProducerEngine {
                                             None,
                                             producer_options,
                                         )
-                                        .map(|r| tx.send(r.map(Arc::new)).map_err(drop).expect("FIXME"));
+                                        .map(|r| {
+                                            tx.send(r.map(Arc::new)).map_err(drop).expect("FIXME")
+                                        }).await;
                                 };
                                 self.pulsar.executor().spawn(Box::pin(f));
                                 Box::pin(rx)

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,20 +1,21 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::pin::Pin;
 
-use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
-use futures::sync::oneshot;
+use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures::channel::oneshot;
 use futures::{
-    future::{self, Either},
-    Future,
+    future::try_join_all,
+    Future, FutureExt, TryFutureExt, StreamExt,
+    task::{Context, Poll},
 };
 use rand;
-use tokio::prelude::*;
 
 use crate::client::SerializeMessage;
 use crate::connection::{Authentication, Connection, SerialId};
 use crate::error::ProducerError;
-use crate::executor::PulsarExecutor;
+use crate::executor::Executor;
 use crate::message::proto::{self, EncryptionKeys, Schema};
 use crate::{Error, Pulsar};
 
@@ -65,33 +66,33 @@ impl Producer {
     pub fn new(pulsar: Pulsar, options: ProducerOptions) -> Producer {
         let (tx, rx) = unbounded();
         let executor = pulsar.executor().clone();
-        executor.spawn(ProducerEngine {
+        executor.spawn(Box::pin(ProducerEngine {
             pulsar,
             inbound: rx,
             producers: BTreeMap::new(),
             new_producers: BTreeMap::new(),
             producer_options: options,
-        });
+        }.map(|res| info!("FIXME: ProducerEngine returned {:?}", res))));
         Producer { message_sender: tx }
     }
 
-    pub fn send<T: SerializeMessage + ?Sized, S: Into<String>>(
+    pub async fn send<T: SerializeMessage + ?Sized, S: Into<String>>(
         &self,
         topic: S,
         message: &T,
-    ) -> impl Future<Item = proto::CommandSendReceipt, Error = Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         let topic = topic.into();
         match T::serialize_message(message) {
-            Ok(message) => Either::A(self.send_message(topic, message)),
-            Err(e) => Either::B(future::failed(e)),
+            Ok(message) => self.send_message(topic, message).await,
+            Err(e) => Err(e),
         }
     }
 
-    pub fn send_all<'a, 'b, T, S, I>(
+    pub async fn send_all<'a, 'b, T, S, I>(
         &self,
         topic: S,
         messages: I,
-    ) -> impl Future<Item = Vec<proto::CommandSendReceipt>, Error = Error>
+    ) -> Result<Vec<proto::CommandSendReceipt>, Error>
     where
         'b: 'a,
         T: 'b + SerializeMessage + ?Sized,
@@ -106,29 +107,31 @@ impl Producer {
             .map(|m| T::serialize_message(m))
             .collect::<Result<Vec<_>, _>>()
         {
-            Ok(messages) => Either::A(future::collect(
-                messages
-                    .into_iter()
-                    .map(|m| self.send_message(topic.clone(), m))
-                    .collect::<Vec<_>>(),
-            )),
-            Err(e) => Either::B(future::failed(e)),
+            Ok(messages) => {
+                let mut v = vec![];
+                for m in messages.into_iter() {
+                    v.push(self.send_message(topic.clone(), m));
+                }
+
+                try_join_all(v).await
+            }
+            Err(e) => Err(e),
         }
     }
 
-    fn send_message<S: Into<String>>(
+    async fn send_message<S: Into<String>>(
         &self,
         topic: S,
         message: Message,
-    ) -> impl Future<Item = proto::CommandSendReceipt, Error = Error> + 'static {
+    ) ->  Result<proto::CommandSendReceipt, Error> {
         let (resolver, future) = oneshot::channel();
         match self.message_sender.unbounded_send(ProducerMessage {
             topic: topic.into(),
             message,
             resolver,
         }) {
-            Ok(_) => Either::A(future.then(|r| {
-                match r {
+            Ok(_) => {
+                match future.await {
                     Ok(Ok(data)) => Ok(data),
                     Ok(Err(e)) => Err(e),
                     Err(oneshot::Canceled) => Err(ProducerError::Custom(
@@ -136,13 +139,13 @@ impl Producer {
                     )
                     .into()),
                 }
-            })),
-            Err(_) => Either::B(future::failed(
+            },
+            Err(_) => Err(
                 ProducerError::Custom(
                     "Unexpected error: pulsar producer engine unexpectedly dropped".to_owned(),
                 )
                 .into(),
-            )),
+            ),
         }
     }
 }
@@ -156,20 +159,19 @@ struct ProducerEngine {
 }
 
 impl Future for ProducerEngine {
-    type Item = ();
-    type Error = ();
+    type Output = Result<(), ()>;
 
-    fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
         if !self.new_producers.is_empty() {
             let mut resolved_topics = Vec::new();
             for (topic, producer) in self.new_producers.iter_mut() {
-                match producer.poll() {
-                    Ok(Async::Ready(Ok(producer))) => {
+                match producer.poll_unpin(cx) {
+                    Poll::Ready(Ok(Ok(producer))) => {
                         self.producers.insert(producer.topic().to_owned(), producer);
                         resolved_topics.push(topic.clone());
                     }
-                    Ok(Async::Ready(Err(_))) | Err(_) => resolved_topics.push(topic.clone()),
-                    Ok(Async::NotReady) => {}
+                    Poll::Ready(Ok(Err(_))) | Poll::Ready(Err(_)) => resolved_topics.push(topic.clone()),
+                    Poll::Pending => {}
                 }
             }
             for topic in resolved_topics {
@@ -178,7 +180,12 @@ impl Future for ProducerEngine {
         }
 
         loop {
-            match try_ready!(self.inbound.poll()) {
+            let r = match self.inbound.poll_next_unpin(cx) {
+              Poll::Pending => return Poll::Pending,
+              Poll::Ready(t) => t,
+            };
+
+            match r {
                 Some(ProducerMessage {
                     topic,
                     message,
@@ -186,51 +193,69 @@ impl Future for ProducerEngine {
                 }) => {
                     match self.producers.get(&topic) {
                         Some(producer) => {
-                            tokio::spawn(
-                                producer
+                            let f = producer.clone()
                                     .send_message(message, None)
-                                    .then(|r| resolver.send(r).map_err(drop)),
-                            );
+                                    .map(|r| resolver.send(r).expect("FIXME"));//.map_err(drop)),
+                            tokio::spawn(f);
                         }
                         None => {
                             let pending = self.new_producers.remove(&topic).unwrap_or_else(|| {
-                                let (tx, rx) = oneshot::channel();
-                                tokio::spawn({
-                                    self.pulsar
+                                let (tx, rx) = oneshot::channel::<Result<Arc<TopicProducer>, Error>>();
+                                let f = self.pulsar.clone()
                                         .create_producer(
                                             topic.clone(),
                                             None,
                                             self.producer_options.clone(),
                                         )
-                                        .then(|r| tx.send(r.map(Arc::new)).map_err(drop))
-                                });
+                                        .map(|r| tx.send(r.map(Arc::new)).map_err(drop).expect("FIXME"));
+                                tokio::spawn(f);
                                 rx
                             });
-                            let (tx, rx) = oneshot::channel();
-                            tokio::spawn(pending.map_err(drop).and_then(move |r| match r {
-                                Ok(producer) => {
-                                    let _ = tx.send(Ok(producer.clone()));
-                                    Either::A(
-                                        producer
+                            let (tx, rx) = oneshot::channel::<Result<Arc<TopicProducer>, Error>>();
+                            let f = async {
+                                match pending//.map_err(drop)
+                                    .await {
+                                    Ok(Ok(producer)) => {
+                                        let _ = tx.send(Ok(producer.clone()));
+                                            producer
                                             .send_message(message, None)
-                                            .then(|r| resolver.send(r))
-                                            .map_err(drop),
-                                    )
+                                            .map(|r| resolver.send(r).expect("FIXME")).await
+                                            //.map_err(drop),
+                                    },
+                                    Ok(Err(e)) => {
+                                        // TODO find better error propagation here
+                                        let _ = resolver.send(Err(Error::Producer(
+                                                    //FIXME
+                                                    //ProducerError::Custom(e.to_string()),
+                                                    ProducerError::Custom("()".to_string()),
+                                                    )));
+                                        let _ = tx.send(Err(Error::Producer(
+                                                    //FIXME
+                                                    //ProducerError::Custom(e.to_string()),
+                                                    ProducerError::Custom("()".to_string()),
+                                                    )));
+                                    }
+                                    Err(e) => {
+                                        // TODO find better error propagation here
+                                        let _ = resolver.send(Err(Error::Producer(
+                                                    //FIXME
+                                                    //ProducerError::Custom(e.to_string()),
+                                                    ProducerError::Custom("()".to_string()),
+                                                    )));
+                                        let _ = tx.send(Err(Error::Producer(
+                                                    //FIXME
+                                                    //ProducerError::Custom(e.to_string()),
+                                                    ProducerError::Custom("()".to_string()),
+                                                    )));
+                                    }
                                 }
-                                Err(e) => {
-                                    // TODO find better error propogation here
-                                    let _ = resolver.send(Err(Error::Producer(
-                                        ProducerError::Custom(e.to_string()),
-                                    )));
-                                    let _ = tx.send(Err(e));
-                                    Either::B(future::failed(()))
-                                }
-                            }));
+                            };
+                            tokio::spawn(f);
                             self.new_producers.insert(topic, rx);
                         }
                     }
                 }
-                None => return Ok(Async::Ready(())),
+                None => return Poll::Ready(Ok(())),
             }
         }
     }
@@ -251,7 +276,7 @@ pub struct TopicProducer {
 }
 
 impl TopicProducer {
-    pub fn new<S1, S2, E: PulsarExecutor>(
+    pub fn new<S1, S2, E: Executor+'static>(
         addr: S1,
         topic: S2,
         name: Option<String>,
@@ -259,7 +284,7 @@ impl TopicProducer {
         proxy_to_broker_url: Option<String>,
         options: ProducerOptions,
         executor: E,
-    ) -> impl Future<Item = TopicProducer, Error = Error>
+    ) -> impl Future<Output = Result<TopicProducer, Error>>
     where
         S1: Into<String>,
         S2: Into<String>,
@@ -271,36 +296,31 @@ impl TopicProducer {
             })
     }
 
-    pub fn from_connection<S: Into<String>>(
+    pub async fn from_connection<S: Into<String>>(
         connection: Arc<Connection>,
         topic: S,
         name: Option<String>,
         options: ProducerOptions,
-    ) -> impl Future<Item = TopicProducer, Error = Error> {
+    ) -> Result<TopicProducer, Error> {
         let topic = topic.into();
         let producer_id = rand::random();
         let sequence_ids = SerialId::new();
 
         let sender = connection.sender().clone();
-        connection
+        let _ = connection
             .sender()
-            .lookup_topic(topic.clone(), false)
-            .map_err(|e| e.into())
-            .and_then({
-                let topic = topic.clone();
-                move |_| {
-                    sender
-                        .create_producer(topic.clone(), producer_id, name, options)
-                        .map_err(|e| e.into())
-                }
-            })
-            .map(move |success| TopicProducer {
-                connection,
-                id: producer_id,
-                name: success.producer_name,
-                topic,
-                message_id: sequence_ids,
-            })
+            .lookup_topic(topic.clone(), false).await?;
+
+        let topic = topic.clone();
+        let success = sender
+            .create_producer(topic.clone(), producer_id, name, options).await?;
+        Ok(TopicProducer {
+            connection,
+            id: producer_id,
+            name: success.producer_name,
+            topic,
+            message_id: sequence_ids,
+        })
     }
 
     pub fn is_valid(&self) -> bool {
@@ -311,18 +331,17 @@ impl TopicProducer {
         &self.topic
     }
 
-    pub fn check_connection(&self) -> impl Future<Item = (), Error = Error> {
+    pub async fn check_connection(&self) -> Result<(), Error> {
         self.connection
             .sender()
-            .lookup_topic("test", false)
-            .map(|_| ())
-            .map_err(|e| e.into())
+            .lookup_topic("test", false).await?;
+        Ok(())
     }
 
-    pub fn send_raw(
+    pub async fn send_raw(
         &self,
         message: Message,
-    ) -> impl Future<Item = proto::CommandSendReceipt, Error = Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         self.connection
             .sender()
             .send(
@@ -331,18 +350,18 @@ impl TopicProducer {
                 self.message_id.get(),
                 None,
                 message,
-            )
+            ).await
             .map_err(|e| e.into())
     }
 
-    pub fn send<T: SerializeMessage + ?Sized>(
+    pub async fn send<T: SerializeMessage + ?Sized>(
         &self,
         message: &T,
         num_messages: Option<i32>,
-    ) -> impl Future<Item = proto::CommandSendReceipt, Error = Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         match T::serialize_message(message) {
-            Ok(message) => Either::A(self.send_message(message, num_messages)),
-            Err(e) => Either::B(future::failed(e)),
+            Ok(message) => self.send_message(message, num_messages).await,
+            Err(e) => Err(e),
         }
     }
 
@@ -352,11 +371,11 @@ impl TopicProducer {
             .map(|e| ProducerError::Connection(e).into())
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         message: Message,
         num_messages: Option<i32>,
-    ) -> impl Future<Item = proto::CommandSendReceipt, Error = Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         self.connection
             .sender()
             .send(
@@ -365,7 +384,7 @@ impl TopicProducer {
                 self.message_id.get(),
                 num_messages,
                 message,
-            )
+            ).await
             .map_err(|e| ProducerError::Connection(e).into())
     }
 }


### PR DESCRIPTION
it is not finished yet, but at least it compiles and the tests run :smile: 
It includes dependency updates for bytes, prost, prost-derive, tokio, futures-timer and trust-dns-resolver since those were also converted to the new futures.
I converted a large part of the code to async/await since it solves some compilation issues, an overall it makes the code a bit easier to follow