### PR TITLE
Expose TokioExecutor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use consumer::{
     Ack, Consumer, ConsumerBuilder, ConsumerOptions, ConsumerState, Message, MultiTopicConsumer,
 };
 pub use error::{ConnectionError, ConsumerError, Error, ProducerError, ServiceDiscoveryError};
-pub use executor::{Executor, TaskExecutor};
+pub use executor::{Executor, TaskExecutor, TokioExecutor};
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};


### PR DESCRIPTION
Currently creating a Pulsar instance within a tokio app is impossible given that TokioExecutor is private. This PR exposes it so that it can be used