### PR TITLE
replace connection::Sender with a spawned task

### DIFF
--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate serde;
 use log::{Record, Metadata, LevelFilter};
-use pulsar::{Message, Consumer, Pulsar, TokioExecutor,
+use pulsar::{Consumer, Pulsar, TokioExecutor,
   message::Payload, SerializeMessage, DeserializeMessage, Error as PulsarError,
   message::proto::command_subscribe::SubType, producer,
   message::proto};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,14 +23,6 @@ pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};
 pub use service_discovery::ServiceDiscovery;
 
-macro_rules! try_ready {
-    ($e:expr) => (match $e {
-        $crate::futures::task::Poll::Ready(Ok(t)) => t,
-        $crate::futures::task::Poll::Pending => return $crate::futures::task::Poll::Pending,
-        $crate::futures::task::Poll::Ready(Err(e)) => return $crate::futures::task::Poll::Ready(Err(From::from(e))),
-    })
-}
-
 mod client;
 mod connection;
 mod connection_manager;


### PR DESCRIPTION
this simplifies the code significantly (replacing a custom Future implementation with a 6 lines async block)