### PR TITLE
async-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,18 @@ futures = "0.3"
 nom = "5.0.0"
 prost = "0.6.0"
 prost-derive = "0.6.0"
-tokio = {version = "0.2", features = ["rt-threaded"]}
+tokio = { version = "0.2", features = ["rt-threaded", "blocking", "full"]}
 tokio-util = {version = "0.3", features = ["codec"] }
 rand = "0.7"
 chrono = "0.4.6"
 futures-timer = "3.0"
 log = "0.4.6"
-trust-dns-resolver = "0.19"
 url = "2.1"
 regex = "1.1.7"
 bit-vec = "0.6"
+futures_codec = "0.4"
+futures-io = "0.3"
+async-std = {version = "1.5", features = [ "attributes", "unstable" ] }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
 zstd = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 nom = "5.0.0"
 prost = "0.6.0"
 prost-derive = "0.6.0"
-tokio = { version = "0.2", features = ["rt-threaded", "blocking", "full"]}
-tokio-util = {version = "0.3", features = ["codec"] }
+tokio = { version = "0.2", features = ["rt-threaded", "blocking", "full"], optional = true }
+tokio-util = {version = "0.3", features = ["codec"], optional = true }
 rand = "0.7"
 chrono = "0.4.6"
 futures-timer = "3.0"
@@ -34,9 +34,9 @@ log = "0.4.6"
 url = "2.1"
 regex = "1.1.7"
 bit-vec = "0.6"
-futures_codec = "0.4"
 futures-io = "0.3"
-async-std = {version = "1.5", features = [ "attributes", "unstable" ] }
+async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
+futures_codec = { version = "0.4", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
 zstd = { version = "0.4", optional = true }
@@ -50,5 +50,7 @@ serde_json = "1.0.40"
 prost-build = "0.6.0"
 
 [features]
-default = [ "compression" ]
+default = [ "compression", "tokio-runtime", "async-std-runtime" ]
 compression = [ "lz4", "flate2", "zstd", "snap" ]
+tokio-runtime = [ "tokio", "tokio-util" ]
+async-std-runtime = [ "async-std", "futures_codec" ]

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -60,8 +60,7 @@ fn main() {
 
     let producer = async {
         let addr = "localhost";
-        let executor = TokioExecutor(tokio::runtime::Handle::current());
-        let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+        let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
         let producer = pulsar.create_producer("test", Some("my-producer".to_string()), producer::ProducerOptions {
             schema: Some(proto::Schema {
                       type_: proto::schema::Type::String as i32,
@@ -87,8 +86,7 @@ fn main() {
 
     let consumer = async {
         let addr = "localhost";
-        let executor = TokioExecutor(tokio::runtime::Handle::current());
-        let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+        let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
 
         let mut consumer: Consumer<TestData> = pulsar
             .consumer()

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use crate::connection::Authentication;
 use crate::connection_manager::{BrokerAddress, ConnectionManager};
 use crate::consumer::{Consumer, ConsumerBuilder, ConsumerOptions, MultiTopicConsumer, Unset};
 use crate::error::Error;
-use crate::executor::PulsarExecutor;
+use crate::executor::Executor;
 use crate::message::proto::{self, command_subscribe::SubType, CommandSendReceipt};
 use crate::message::Payload;
 use crate::producer::{self, Producer, ProducerOptions, TopicProducer};
@@ -82,12 +82,12 @@ impl SerializeMessage for str {
 //TODO add more DeserializeMessage impls
 
 #[derive(Clone)]
-pub struct Pulsar<E: PulsarExecutor + ?Sized> {
+pub struct Pulsar<E: Executor + ?Sized> {
     manager: Arc<ConnectionManager<E>>,
     service_discovery: Arc<ServiceDiscovery<E>>,
 }
 
-impl<Exe: PulsarExecutor> Pulsar<Exe> {
+impl<Exe: Executor> Pulsar<Exe> {
     pub async fn new<S: Into<String>>(
         addr: S,
         auth: Option<Authentication>,
@@ -329,8 +329,4 @@ impl<Exe: PulsarExecutor> Pulsar<Exe> {
     pub fn producer(&self, options: Option<ProducerOptions>) -> Producer {
         Producer::new(self.clone(), options.unwrap_or_default())
     }
-
-    /*pub(crate) fn executor(&self) -> &TaskExecutor {
-        &self.executor
-    }*/
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -19,7 +19,7 @@ use tokio_util;
 
 use crate::consumer::ConsumerOptions;
 use crate::error::{ConnectionError, SharedError};
-use crate::executor::{PulsarExecutor, ExecutorKind};
+use crate::executor::{Executor, ExecutorKind};
 use crate::message::{
     proto::{self, command_subscribe::SubType},
     Codec, Message,
@@ -433,7 +433,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub async fn new<Exe: PulsarExecutor + ?Sized>(
+    pub async fn new<Exe: Executor + ?Sized>(
         addr: String,
         auth_data: Option<Authentication>,
         proxy_to_broker_url: Option<String>,
@@ -457,7 +457,7 @@ impl Connection {
         }
     }
 
-    pub async fn from_stream<Exe: PulsarExecutor+ ?Sized, S>(
+    pub async fn from_stream<Exe: Executor+ ?Sized, S>(
         addr: String,
         mut stream: S,
         auth_data: Option<Authentication>,
@@ -554,10 +554,6 @@ impl Connection {
     pub fn sender(&self) -> &ConnectionSender {
         &self.sender
     }
-
-    /*pub fn executor(&self) -> TaskExecutor {
-        self.executor.clone()
-    }*/
 }
 
 impl Drop for Connection {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,9 +1,10 @@
 use crate::connection::{Authentication, Connection};
 use crate::error::ConnectionError;
-use crate::executor::{Executor, TaskExecutor};
+use crate::executor::PulsarExecutor;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::marker::PhantomData;
 
 /// holds connection information for a broker
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -22,38 +23,34 @@ pub struct BrokerAddress {
 /// interacting with a cluster. It will automatically follow redirects
 /// or use a proxy, and aggregate broker connections
 #[derive(Clone)]
-pub struct ConnectionManager {
+pub struct ConnectionManager<Exe: PulsarExecutor + ?Sized> {
     pub address: SocketAddr,
     base: Arc<Connection>,
     auth: Option<Authentication>,
-    executor: TaskExecutor,
+    executor: PhantomData<Exe>,
     connections: Arc<Mutex<HashMap<BrokerAddress, Arc<Connection>>>>,
 }
 
-impl ConnectionManager {
-    pub async fn new<E: Executor + 'static>(
+impl<Exe: PulsarExecutor> ConnectionManager<Exe> {
+    pub async fn new(
         addr: SocketAddr,
         auth: Option<Authentication>,
-        executor: E,
     ) -> Result<Self, ConnectionError> {
-        let executor = TaskExecutor::new(executor);
-        let conn = Connection::new(addr.to_string(), auth.clone(), None, executor.clone()).await?;
-        ConnectionManager::from_connection(conn, auth, addr, executor)
+        let conn = Connection::new::<Exe>(addr.to_string(), auth.clone(), None).await?;
+        ConnectionManager::from_connection(conn, auth, addr)
     }
 
-    pub fn from_connection<E: Executor + 'static>(
+    pub fn from_connection(
         connection: Connection,
         auth: Option<Authentication>,
         address: SocketAddr,
-        executor: E,
-    ) -> Result<ConnectionManager, ConnectionError> {
-        let executor = TaskExecutor::new(executor);
+    ) -> Result<Self, ConnectionError> {
         let base = Arc::new(connection);
         Ok(ConnectionManager {
             address,
             base,
             auth,
-            executor,
+            executor: PhantomData,
             connections: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -116,11 +113,10 @@ impl ConnectionManager {
             None
         };
 
-        let conn = Connection::new(
+        let conn = Connection::new::<Exe>(
             broker.address.to_string(),
             self.auth.clone(),
             proxy_url,
-            self.executor.clone(),
         )
         .await?;
         let c = Arc::new(conn);

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,6 +1,6 @@
 use crate::connection::{Authentication, Connection};
 use crate::error::ConnectionError;
-use crate::executor::PulsarExecutor;
+use crate::executor::Executor;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
@@ -23,7 +23,7 @@ pub struct BrokerAddress {
 /// interacting with a cluster. It will automatically follow redirects
 /// or use a proxy, and aggregate broker connections
 #[derive(Clone)]
-pub struct ConnectionManager<Exe: PulsarExecutor + ?Sized> {
+pub struct ConnectionManager<Exe: Executor + ?Sized> {
     pub address: SocketAddr,
     base: Arc<Connection>,
     auth: Option<Authentication>,
@@ -31,7 +31,7 @@ pub struct ConnectionManager<Exe: PulsarExecutor + ?Sized> {
     connections: Arc<Mutex<HashMap<BrokerAddress, Arc<Connection>>>>,
 }
 
-impl<Exe: PulsarExecutor> ConnectionManager<Exe> {
+impl<Exe: Executor> ConnectionManager<Exe> {
     pub async fn new(
         addr: SocketAddr,
         auth: Option<Authentication>,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 
 use crate::connection:: Connection;
 use crate::error::{ConnectionError, ConsumerError, Error};
-use crate::executor::PulsarExecutor;
+use crate::executor::{PulsarExecutor, Interval};
 use crate::message::{
     parse_batched_message,
     proto::{self, command_subscribe::SubType, MessageIdData, Schema},
@@ -259,7 +259,7 @@ struct NackHandler {
     conn: Arc<Connection>,
     inbound: Option<Pin<Box<UnboundedReceiver<NackMessage>>>>,
     unack_redelivery_delay: Option<Duration>,
-    tick_timer: Pin<Box<tokio::time::Interval>>,
+    tick_timer: Pin<Box<Interval>>,
     batch_messages: BTreeMap<MessageIdData, (bool, BitVec)>,
 }
 
@@ -278,7 +278,7 @@ impl NackHandler {
             conn,
             inbound: Some(Box::pin(rx)),
             unack_redelivery_delay: redelivery_delay,
-            tick_timer: Box::pin(tokio::time::interval(tick_delay)),
+            tick_timer: Box::pin(Exe::interval(tick_delay)),
             batch_messages: BTreeMap::new(),
         }.map(|res| trace!("AckHandler returned {:?}", res)))) {
             error!("the executor could not spawn the AckHandler future");

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -53,36 +53,7 @@ pub struct Consumer<T: DeserializeMessage> {
 }
 
 impl<T: DeserializeMessage> Consumer<T> {
-    /*pub async fn new<E: Executor+'static>(
-        addr: String,
-        topic: String,
-        subscription: String,
-        sub_type: SubType,
-        consumer_id: Option<u64>,
-        consumer_name: Option<String>,
-        auth_data: Option<Authentication>,
-        proxy_to_broker_url: Option<String>,
-        executor: E,
-        batch_size: Option<u32>,
-        unacked_message_redelivery_delay: Option<Duration>,
-        options: ConsumerOptions,
-    ) -> Result<Consumer<T>, Error> {
-        let conn = Connection::new(addr, auth_data, proxy_to_broker_url, executor)
-            .await?;
-        Consumer::from_connection(
-            Arc::new(conn),
-            topic,
-            subscription,
-            sub_type,
-            consumer_id,
-            consumer_name,
-            batch_size,
-            unacked_message_redelivery_delay,
-            options,
-            ).await
-    }*/
-
-    pub async fn from_connection<Exe: PulsarExecutor>(
+    pub async fn from_connection<Exe: Executor>(
         connection: Arc<Connection>,
         topic: String,
         subscription: String,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -906,7 +906,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             topics: VecDeque::new(),
             new_consumers: None,
             refresh: Box::pin(
-                tokio::time::interval(topic_refresh)
+                Exe::interval(topic_refresh)
                     .map(drop)
                     //.map_err(|e| panic!("error creating referesh timer: {}", e)),
             ),
@@ -1095,10 +1095,13 @@ mod tests {
     use std::thread;
 
     use regex::Regex;
+    #[cfg(feature = "tokio-runtime")]
     use tokio::runtime::Runtime;
     use log::{LevelFilter};
 
-    use crate::{producer, Pulsar, SerializeMessage, executor::TokioExecutor, tests::TEST_LOGGER};
+    use crate::{producer, Pulsar, SerializeMessage, tests::TEST_LOGGER};
+    #[cfg(feature = "tokio-runtime")]
+    use crate::executor::TokioExecutor;
 
     use super::*;
 
@@ -1128,6 +1131,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(feature = "tokio-runtime")]
     fn multi_consumer() {
         let _ = log::set_logger(&TEST_LOGGER);
         let _ = log::set_max_level(LevelFilter::Debug);
@@ -1230,8 +1234,10 @@ mod tests {
         }
 
     }
+
     #[test]
     #[ignore]
+    #[cfg(feature = "tokio-runtime")]
     fn consumer_dropped_with_lingering_acks() {
         use rand::{Rng, distributions::Alphanumeric};
         let _ = log::set_logger(&TEST_LOGGER);

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -13,9 +13,9 @@ use futures::task::{Context, Poll};
 use rand;
 use regex::Regex;
 
-use crate::connection::{Authentication, Connection};
+use crate::connection:: Connection;
 use crate::error::{ConnectionError, ConsumerError, Error};
-use crate::executor::{Executor, TaskExecutor};
+use crate::executor::PulsarExecutor;
 use crate::message::{
     parse_batched_message,
     proto::{self, command_subscribe::SubType, MessageIdData, Schema},
@@ -53,7 +53,7 @@ pub struct Consumer<T: DeserializeMessage> {
 }
 
 impl<T: DeserializeMessage> Consumer<T> {
-    pub async fn new<E: Executor+'static>(
+    /*pub async fn new<E: Executor+'static>(
         addr: String,
         topic: String,
         subscription: String,
@@ -80,9 +80,9 @@ impl<T: DeserializeMessage> Consumer<T> {
             unacked_message_redelivery_delay,
             options,
             ).await
-    }
+    }*/
 
-    pub async fn from_connection(
+    pub async fn from_connection<Exe: PulsarExecutor>(
         connection: Arc<Connection>,
         topic: String,
         subscription: String,
@@ -115,11 +115,10 @@ impl<T: DeserializeMessage> Consumer<T> {
         //TODO this should be shared among all consumers when using the client
         //TODO make tick_delay configurable
         let tick_delay = Duration::from_millis(500);
-        let nack_handler = NackHandler::new(
+        let nack_handler = NackHandler::new::<Exe>(
             connection.clone(),
             unacked_message_redelivery_delay,
             tick_delay,
-            connection.executor(),
             );
 
         // drop_signal will be dropped when Consumer is dropped, then
@@ -127,7 +126,7 @@ impl<T: DeserializeMessage> Consumer<T> {
         let (_drop_signal, drop_receiver) = oneshot::channel::<()>();
         let conn = connection.clone();
         let ack_sender = nack_handler.clone();
-        let _ = connection.executor().spawn(Box::pin(async move {
+        let _ = Exe::spawn(Box::pin(async move {
             let _res = drop_receiver.await;
             ack_sender.close_channel();
             if let Err(e) = conn.sender().close_consumer(consumer_id).await {
@@ -267,16 +266,14 @@ struct NackHandler {
 impl NackHandler {
     /// Create and spawn a new NackHandler future, which will run until the connection fails, or all
     /// inbound senders are dropped and any pending redelivery messages have been sent
-    pub fn new<E: Executor+'static>(
+    pub fn new<Exe: PulsarExecutor + ?Sized>(
         conn: Arc<Connection>,
         redelivery_delay: Option<Duration>,
         tick_delay: Duration,
-        executor: E,
     ) -> UnboundedSender<NackMessage> {
         let (tx, rx) = mpsc::unbounded();
-        let executor = TaskExecutor::new(executor);
 
-        if let Err(_) = executor.clone().spawn(Box::pin(NackHandler {
+        if let Err(_) = Exe::spawn(Box::pin(NackHandler {
             pending_nacks: BinaryHeap::new(),
             conn,
             inbound: Some(Box::pin(rx)),
@@ -617,8 +614,8 @@ pub struct Set<T>(T);
 
 pub struct Unset;
 
-pub struct ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
-    pulsar: &'a Pulsar,
+pub struct ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe: PulsarExecutor + ?Sized> {
+    pulsar: &'a Pulsar<Exe>,
     topic: Topic,
     subscription: Subscription,
     subscription_type: SubscriptionType,
@@ -633,8 +630,8 @@ pub struct ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
     topic_refresh: Option<Duration>,
 }
 
-impl<'a> ConsumerBuilder<'a, Unset, Unset, Unset> {
-    pub fn new(pulsar: &'a Pulsar) -> Self {
+impl<'a, Exe: PulsarExecutor + ?Sized> ConsumerBuilder<'a, Unset, Unset, Unset, Exe> {
+    pub fn new(pulsar: &'a Pulsar<Exe>) -> Self {
         ConsumerBuilder {
             pulsar,
             topic: Unset,
@@ -652,13 +649,13 @@ impl<'a> ConsumerBuilder<'a, Unset, Unset, Unset> {
     }
 }
 
-impl<'a, Subscription, SubscriptionType>
-    ConsumerBuilder<'a, Unset, Subscription, SubscriptionType>
+impl<'a, Subscription, SubscriptionType, Exe: PulsarExecutor + ?Sized>
+    ConsumerBuilder<'a, Unset, Subscription, SubscriptionType, Exe>
 {
     pub fn with_topic<S: Into<String>>(
         self,
         topic: S,
-    ) -> ConsumerBuilder<'a, Set<String>, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Set<String>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: Set(topic.into()),
@@ -677,7 +674,7 @@ impl<'a, Subscription, SubscriptionType>
     pub fn multi_topic(
         self,
         regex: Regex,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: Set(regex),
@@ -694,11 +691,11 @@ impl<'a, Subscription, SubscriptionType>
     }
 }
 
-impl<'a, Topic, SubscriptionType> ConsumerBuilder<'a, Topic, Unset, SubscriptionType> {
+impl<'a, Topic, SubscriptionType, Exe: PulsarExecutor + ?Sized> ConsumerBuilder<'a, Topic, Unset, SubscriptionType, Exe> {
     pub fn with_subscription<S: Into<String>>(
         self,
         subscription: S,
-    ) -> ConsumerBuilder<'a, Topic, Set<String>, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Topic, Set<String>, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             subscription: Set(subscription.into()),
@@ -715,11 +712,11 @@ impl<'a, Topic, SubscriptionType> ConsumerBuilder<'a, Topic, Unset, Subscription
     }
 }
 
-impl<'a, Topic, Subscription> ConsumerBuilder<'a, Topic, Subscription, Unset> {
+impl<'a, Topic, Subscription, Exe: PulsarExecutor + ?Sized> ConsumerBuilder<'a, Topic, Subscription, Unset, Exe> {
     pub fn with_subscription_type(
         self,
         subscription_type: SubType,
-    ) -> ConsumerBuilder<'a, Topic, Subscription, Set<SubType>> {
+    ) -> ConsumerBuilder<'a, Topic, Subscription, Set<SubType>, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             subscription_type: Set(subscription_type),
@@ -736,13 +733,13 @@ impl<'a, Topic, Subscription> ConsumerBuilder<'a, Topic, Subscription, Unset> {
     }
 }
 
-impl<'a, Subscription, SubscriptionType>
-    ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType>
+impl<'a, Subscription, SubscriptionType, Exe: PulsarExecutor + ?Sized>
+    ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe>
 {
     pub fn with_namespace<S: Into<String>>(
         self,
         namespace: S,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: self.topic,
@@ -761,7 +758,7 @@ impl<'a, Subscription, SubscriptionType>
     pub fn with_topic_refresh(
         self,
         refresh_interval: Duration,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: self.topic,
@@ -778,13 +775,13 @@ impl<'a, Subscription, SubscriptionType>
     }
 }
 
-impl<'a, Topic, Subscription, SubscriptionType>
-    ConsumerBuilder<'a, Topic, Subscription, SubscriptionType>
+impl<'a, Topic, Subscription, SubscriptionType, Exe: PulsarExecutor + ?Sized>
+    ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe>
 {
     pub fn with_consumer_id(
         mut self,
         consumer_id: u64,
-    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe> {
         self.consumer_id = Some(consumer_id);
         self
     }
@@ -792,7 +789,7 @@ impl<'a, Topic, Subscription, SubscriptionType>
     pub fn with_consumer_name<S: Into<String>>(
         mut self,
         consumer_name: S,
-    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe> {
         self.consumer_name = Some(consumer_name.into());
         self
     }
@@ -800,7 +797,7 @@ impl<'a, Topic, Subscription, SubscriptionType>
     pub fn with_batch_size(
         mut self,
         batch_size: u32,
-    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe> {
         self.batch_size = Some(batch_size);
         self
     }
@@ -808,7 +805,7 @@ impl<'a, Topic, Subscription, SubscriptionType>
     pub fn with_options(
         mut self,
         options: ConsumerOptions,
-    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType> {
+    ) -> ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe> {
         self.consumer_options = Some(options);
         self
     }
@@ -822,7 +819,7 @@ impl<'a, Topic, Subscription, SubscriptionType>
     }
 }
 
-impl<'a> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubType>> {
+impl<'a, Exe: PulsarExecutor> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubType>, Exe> {
     pub async fn build<T: DeserializeMessage>(self) -> Result<Consumer<T>, Error> {
         let ConsumerBuilder {
             pulsar,
@@ -850,8 +847,8 @@ impl<'a> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubType>> {
     }
 }
 
-impl<'a> ConsumerBuilder<'a, Set<Regex>, Set<String>, Set<SubType>> {
-    pub fn build<T: DeserializeMessage>(self) -> MultiTopicConsumer<T> {
+impl<'a, Exe: PulsarExecutor> ConsumerBuilder<'a, Set<Regex>, Set<String>, Set<SubType>, Exe> {
+    pub fn build<T: DeserializeMessage>(self) -> MultiTopicConsumer<T, Exe> {
         let ConsumerBuilder {
             pulsar,
             topic: Set(topic),
@@ -897,10 +894,10 @@ pub struct ConsumerState {
     pub messages_received: u64,
 }
 
-pub struct MultiTopicConsumer<T: DeserializeMessage> {
+pub struct MultiTopicConsumer<T: DeserializeMessage, Exe: PulsarExecutor> {
     namespace: String,
     topic_regex: Regex,
-    pulsar: Pulsar,
+    pulsar: Pulsar<Exe>,
     unacked_message_resend_delay: Option<Duration>,
     consumers: BTreeMap<String, Pin<Box<Consumer<T>>>>,
     topics: VecDeque<String>,
@@ -914,9 +911,9 @@ pub struct MultiTopicConsumer<T: DeserializeMessage> {
     state_streams: Vec<UnboundedSender<ConsumerState>>,
 }
 
-impl<T: DeserializeMessage> MultiTopicConsumer<T> {
+impl<T: DeserializeMessage, Exe: PulsarExecutor> MultiTopicConsumer<T, Exe> {
     pub fn new<S1, S2>(
-        pulsar: Pulsar,
+        pulsar: Pulsar<Exe>,
         namespace: S1,
         topic_regex: Regex,
         subscription: S2,
@@ -1008,7 +1005,7 @@ pub struct Message<T> {
     message_id: MessageData,
 }
 
-impl<T: DeserializeMessage> Debug for MultiTopicConsumer<T> {
+impl<T: DeserializeMessage, Exe: PulsarExecutor> Debug for MultiTopicConsumer<T, Exe> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -1018,7 +1015,7 @@ impl<T: DeserializeMessage> Debug for MultiTopicConsumer<T> {
     }
 }
 
-impl<T: 'static + DeserializeMessage> Stream for MultiTopicConsumer<T> {
+impl<T: 'static + DeserializeMessage, Exe: PulsarExecutor> Stream for MultiTopicConsumer<T, Exe> {
     type Item = Result<Message<T::Output>, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -1194,8 +1191,7 @@ mod tests {
         let succ = successes.clone();
 
         let f = async move {
-            let executor = TokioExecutor(tokio::runtime::Handle::current());
-            let client: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let client: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
             let producer = client.producer(None);
 
             let send_start = Utc::now();
@@ -1206,7 +1202,7 @@ mod tests {
 
             let data = vec![data1, data2, data3, data4];
 
-            let mut consumer: MultiTopicConsumer<TestData> = client
+            let mut consumer: MultiTopicConsumer<TestData, _> = client
                 .consumer()
                 .multi_topic(Regex::new("mt_test_[ab]").unwrap())
                 .with_namespace(namespace)
@@ -1275,8 +1271,7 @@ mod tests {
         let topic = "issue_51";
 
         let f = async move {
-            let executor = TokioExecutor(tokio::runtime::Handle::current());
-            let client: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let client: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
 
             let message = TestData {
                 topic: std::iter::repeat(()).map(|()| rand::thread_rng().sample(Alphanumeric))

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,15 +1,29 @@
 use futures::future::{Future, FutureExt};
-use std::sync::Arc;
-use std::pin::Pin;
 use std::ops::Deref;
+use std::pin::Pin;
+use std::sync::Arc;
 use tokio::runtime::Handle;
 
 pub trait Executor: Send + Sync {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
 }
 
+pub enum ExecutorKind {
+    Tokio,
+    AsyncStd,
+}
+
 pub trait PulsarExecutor: Clone + Send + Sync + 'static {
     fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
+    fn spawn_blocking<F, Res>(f: F) -> JoinHandle<Res>
+    where
+        F: FnOnce() -> Res + Send + 'static,
+        Res: Send + 'static;
+
+    // test at runtime and manually choose the implementation
+    // because we cannot (yet) have async trait methods,
+    // so we cannot move the TCP connection here
+    fn kind() -> ExecutorKind;
 }
 
 #[derive(Clone)]
@@ -28,8 +42,8 @@ impl TaskExecutor {
     }
 
     fn execute<F>(&self, f: F) -> Result<(), ()>
-        where
-            F: Future<Output = Result<(), ()>> + Send + 'static,
+    where
+        F: Future<Output = Result<(), ()>> + Send + 'static,
     {
         match self.inner.spawn(Box::pin(f.map(|_| ()))) {
             Ok(()) => Ok(()),
@@ -38,14 +52,13 @@ impl TaskExecutor {
     }
 }
 
-impl Executor for TaskExecutor
-{
+impl Executor for TaskExecutor {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         self.inner.deref().spawn(f)
     }
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct TokioExecutor(pub Handle);
 
 impl Executor for TokioExecutor {
@@ -57,8 +70,73 @@ impl Executor for TokioExecutor {
 
 impl PulsarExecutor for TokioExecutor {
     fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
-        let handle = tokio::runtime::Handle::current();
-        handle.spawn(f);
+        tokio::task::spawn(f);
         Ok(())
+    }
+
+    fn spawn_blocking<F, Res>(f: F) -> JoinHandle<Res>
+    where
+        F: FnOnce() -> Res + Send + 'static,
+        Res: Send + 'static,
+    {
+        JoinHandle::Tokio(tokio::task::spawn_blocking(f))
+    }
+
+    fn kind() -> ExecutorKind {
+        ExecutorKind::Tokio
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AsyncStdExecutor;
+
+impl Executor for AsyncStdExecutor {
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
+        async_std::task::spawn(f);
+        Ok(())
+    }
+}
+
+impl PulsarExecutor for AsyncStdExecutor {
+    fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
+        async_std::task::spawn(f);
+        Ok(())
+    }
+
+    fn spawn_blocking<F, Res>(f: F) -> JoinHandle<Res>
+    where
+        F: FnOnce() -> Res + Send + 'static,
+        Res: Send + 'static,
+    {
+        JoinHandle::AsyncStd(async_std::task::spawn_blocking(f))
+    }
+
+    fn kind() -> ExecutorKind {
+        ExecutorKind::AsyncStd
+    }
+}
+
+pub enum JoinHandle<T> {
+    Tokio(tokio::task::JoinHandle<T>),
+    AsyncStd(async_std::task::JoinHandle<T>),
+}
+
+use std::task::Poll;
+impl<T> Future for JoinHandle<T> {
+    type Output = Option<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> std::task::Poll<Self::Output> {
+        unsafe {
+            match Pin::get_unchecked_mut(self) {
+                JoinHandle::Tokio(j) => match Pin::new_unchecked(j).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(v) => Poll::Ready(v.ok()),
+                },
+                JoinHandle::AsyncStd(j) => match Pin::new_unchecked(j).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(v) => Poll::Ready(Some(v)),
+                },
+            }
+        }
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -8,6 +8,10 @@ pub trait Executor: Send + Sync {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
 }
 
+pub trait PulsarExecutor: Clone + Send + Sync + 'static {
+    fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
+}
+
 #[derive(Clone)]
 pub struct TaskExecutor {
     inner: Arc<dyn Executor + Send + Sync + 'static>,
@@ -47,6 +51,14 @@ pub struct TokioExecutor(pub Handle);
 impl Executor for TokioExecutor {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         self.0.spawn(f);
+        Ok(())
+    }
+}
+
+impl PulsarExecutor for TokioExecutor {
+    fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
+        let handle = tokio::runtime::Handle::current();
+        handle.spawn(f);
         Ok(())
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,5 @@
 use futures::{Future, Stream};
 use std::pin::Pin;
-use tokio::runtime::Handle;
 
 pub enum ExecutorKind {
     Tokio,
@@ -22,9 +21,11 @@ pub trait Executor: Clone + Send + Sync + 'static {
     fn kind() -> ExecutorKind;
 }
 
+#[cfg(feature = "tokio-runtime")]
 #[derive(Clone, Debug)]
-pub struct TokioExecutor(pub Handle);
+pub struct TokioExecutor(pub tokio::runtime::Handle);
 
+#[cfg(feature = "tokio-runtime")]
 impl Executor for TokioExecutor {
     fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         tokio::task::spawn(f);
@@ -48,9 +49,11 @@ impl Executor for TokioExecutor {
     }
 }
 
+#[cfg(feature = "async-std-runtime")]
 #[derive(Clone, Debug)]
 pub struct AsyncStdExecutor;
 
+#[cfg(feature = "async-std-runtime")]
 impl Executor for AsyncStdExecutor {
     fn spawn(f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         async_std::task::spawn(f);
@@ -75,8 +78,13 @@ impl Executor for AsyncStdExecutor {
 }
 
 pub enum JoinHandle<T> {
+    #[cfg(feature = "tokio-runtime")]
     Tokio(tokio::task::JoinHandle<T>),
+    #[cfg(feature = "async-std-runtime")]
     AsyncStd(async_std::task::JoinHandle<T>),
+    // here to avoid a compilation error since T is not used
+    #[cfg(all(not(feature = "tokio-runtime"), not(feature = "async-std-runtime")))]
+    PlaceHolder(T),
 }
 
 use std::task::Poll;
@@ -86,38 +94,59 @@ impl<T> Future for JoinHandle<T> {
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> std::task::Poll<Self::Output> {
         unsafe {
             match Pin::get_unchecked_mut(self) {
+                #[cfg(feature = "tokio-runtime")]
                 JoinHandle::Tokio(j) => match Pin::new_unchecked(j).poll(cx) {
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(v) => Poll::Ready(v.ok()),
                 },
+                #[cfg(feature = "async-std-runtime")]
                 JoinHandle::AsyncStd(j) => match Pin::new_unchecked(j).poll(cx) {
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(v) => Poll::Ready(Some(v)),
                 },
+                #[cfg(all(not(feature = "tokio-runtime"), not(feature = "async-std-runtime")))]
+                JoinHandle::PlaceHolder(t) => {
+                    unimplemented!("please activate one of the following cargo features: tokio-runtime, async-std-runtime")
+
+                }
             }
         }
     }
 }
 
 pub enum Interval {
-  Tokio(tokio::time::Interval),
-  AsyncStd(async_std::stream::Interval),
+    #[cfg(feature = "tokio-runtime")]
+    Tokio(tokio::time::Interval),
+    #[cfg(feature = "async-std-runtime")]
+    AsyncStd(async_std::stream::Interval),
+    #[cfg(all(not(feature = "tokio-runtime"), not(feature = "async-std-runtime")))]
+    PlaceHolder,
 }
 
 impl Stream for Interval {
     type Item = ();
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut std::task::Context) -> std::task::Poll<Option<Self::Item>> {
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context,
+    ) -> std::task::Poll<Option<Self::Item>> {
         unsafe {
             match Pin::get_unchecked_mut(self) {
+                #[cfg(feature = "tokio-runtime")]
                 Interval::Tokio(j) => match Pin::new_unchecked(j).poll_next(cx) {
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(v) => Poll::Ready(v.map(|_| ())),
                 },
+                #[cfg(feature = "async-std-runtime")]
                 Interval::AsyncStd(j) => match Pin::new_unchecked(j).poll_next(cx) {
                     Poll::Pending => Poll::Pending,
                     Poll::Ready(v) => Poll::Ready(v),
                 },
+                #[cfg(all(not(feature = "tokio-runtime"), not(feature = "async-std-runtime")))]
+                Interval::PlaceHolder => {
+                    unimplemented!("please activate one of the following cargo features: tokio-runtime, async-std-runtime")
+
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use consumer::{
     Consumer, ConsumerBuilder, ConsumerOptions, ConsumerState, Message, MultiTopicConsumer,
 };
 pub use error::{ConnectionError, ConsumerError, Error, ProducerError, ServiceDiscoveryError};
-pub use executor::{Executor, TaskExecutor, TokioExecutor, AsyncStdExecutor};
+pub use executor::{TokioExecutor, AsyncStdExecutor};
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use consumer::{
     Consumer, ConsumerBuilder, ConsumerOptions, ConsumerState, Message, MultiTopicConsumer,
 };
 pub use error::{ConnectionError, ConsumerError, Error, ProducerError, ServiceDiscoveryError};
-pub use executor::{Executor, TaskExecutor, TokioExecutor};
+pub use executor::{Executor, TaskExecutor, TokioExecutor, AsyncStdExecutor};
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,11 @@ pub use consumer::{
     Consumer, ConsumerBuilder, ConsumerOptions, ConsumerState, Message, MultiTopicConsumer,
 };
 pub use error::{ConnectionError, ConsumerError, Error, ProducerError, ServiceDiscoveryError};
-pub use executor::{TokioExecutor, AsyncStdExecutor};
+pub use executor::Executor;
+#[cfg(feature = "tokio-runtime")]
+pub use executor::TokioExecutor;
+#[cfg(feature = "async-std-runtime")]
+pub use executor::AsyncStdExecutor;
 pub use message::proto;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{Producer, ProducerOptions, TopicProducer};
@@ -38,7 +42,9 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use futures::StreamExt;
+    #[cfg(feature = "tokio-runtime")]
     use tokio;
+    #[cfg(feature = "tokio-runtime")]
     use tokio::runtime::Runtime;
 
     use message::proto::command_subscribe::SubType;
@@ -47,6 +53,7 @@ mod tests {
     use crate::consumer::Message;
     use crate::message::Payload;
     use crate::Error as PulsarError;
+    #[cfg(feature = "tokio-runtime")]
     use crate::executor::TokioExecutor;
 
     use super::*;
@@ -145,6 +152,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(feature = "tokio-runtime")]
     fn round_trip() {
         let mut runtime = Runtime::new().unwrap();
         let _ = log::set_logger(&TEST_LOGGER);
@@ -199,6 +207,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(feature = "tokio-runtime")]
     fn unsized_data() {
         let _ = log::set_logger(&TEST_LOGGER);
         let _ = log::set_max_level(LevelFilter::Debug);
@@ -268,6 +277,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(feature = "tokio-runtime")]
     fn redelivery() {
         let _ = log::set_logger(&TEST_LOGGER);
         let _ = log::set_max_level(LevelFilter::Debug);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod service_discovery;
 mod tests {
     use std::time::{Duration, Instant};
 
-    use futures::{StreamExt, TryStreamExt};
+    use futures::StreamExt;
     use tokio;
     use tokio::runtime::Runtime;
 
@@ -152,8 +152,7 @@ mod tests {
 
         let f = async {
             let addr = "127.0.0.1:6650";
-            let executor = TokioExecutor(tokio::runtime::Handle::current());
-            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
             let producer = pulsar.producer(None);
 
             for _ in 0u16..5000 {
@@ -206,9 +205,8 @@ mod tests {
         let mut runtime = Runtime::new().unwrap();
 
         let f = async {
-            let executor = TokioExecutor(tokio::runtime::Handle::current());
             let addr = "127.0.0.1:6650";
-            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
             let producer = pulsar.producer(None);
 
             // test &str
@@ -284,8 +282,7 @@ mod tests {
 
         let message_count = 10;
         let f = async move {
-            let executor = TokioExecutor(tokio::runtime::Handle::current());
-            let pulsar: Pulsar = Pulsar::new(addr, None, executor).await.unwrap();
+            let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
 
             let producer = pulsar.producer(None);
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -78,6 +78,7 @@ impl Message {
 
 pub struct Codec;
 
+#[cfg(feature = "tokio-runtime")]
 impl tokio_util::codec::Encoder<Message> for Codec {
     type Error = ConnectionError;
 
@@ -125,6 +126,7 @@ impl tokio_util::codec::Encoder<Message> for Codec {
     }
 }
 
+#[cfg(feature = "tokio-runtime")]
 impl tokio_util::codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
@@ -179,6 +181,7 @@ impl tokio_util::codec::Decoder for Codec {
     }
 }
 
+#[cfg(feature = "async-std-runtime")]
 impl futures_codec::Encoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
@@ -227,6 +230,7 @@ impl futures_codec::Encoder for Codec {
     }
 }
 
+#[cfg(feature = "async-std-runtime")]
 impl futures_codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,7 +5,6 @@ use crc::crc32;
 use nom::number::streaming::{be_u16, be_u32};
 use prost::{self, Message as ImplProtobuf};
 use std::io::Cursor;
-use tokio_util::codec::{Decoder, Encoder};
 
 pub use self::proto::BaseCommand;
 pub use self::proto::MessageMetadata as Metadata;
@@ -79,7 +78,7 @@ impl Message {
 
 pub struct Codec;
 
-impl Encoder<Message> for Codec {
+impl tokio_util::codec::Encoder<Message> for Codec {
     type Error = ConnectionError;
 
     fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), ConnectionError> {
@@ -126,7 +125,109 @@ impl Encoder<Message> for Codec {
     }
 }
 
-impl Decoder for Codec {
+impl tokio_util::codec::Decoder for Codec {
+    type Item = Message;
+    type Error = ConnectionError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Message>, ConnectionError> {
+        trace!("Decoder received {} bytes", src.len());
+        if src.len() >= 4 {
+            let mut buf = Cursor::new(src);
+            // `messageSize` refers only to _remaining_ message size, so we add 4 to get total frame size
+            let message_size = buf.get_u32() as usize + 4;
+            let src = buf.into_inner();
+            if src.len() >= message_size {
+                let msg = {
+                    let (buf, command_frame) =
+                        command_frame(&src[..message_size]).map_err(|err| {
+                            ConnectionError::Decoding(format!(
+                                "Error decoding command frame: {:?}",
+                                err
+                            ))
+                        })?;
+                    let command = BaseCommand::decode(command_frame.command)?;
+
+                    let payload = if buf.len() > 0 {
+                        let (buf, payload_frame) = payload_frame(buf).map_err(|err| {
+                            ConnectionError::Decoding(format!(
+                                "Error decoding payload frame: {:?}",
+                                err
+                            ))
+                        })?;
+
+                        // TODO: Check crc32 of payload data
+
+                        let metadata = Metadata::decode(payload_frame.metadata)?;
+                        Some(Payload {
+                            metadata,
+                            data: buf.to_vec(),
+                        })
+                    } else {
+                        None
+                    };
+
+                    Message { command, payload }
+                };
+
+                //TODO advance as we read, rather than this weird post thing
+                src.advance(message_size);
+                //                println!("Read message {:?}", &msg);
+                return Ok(Some(msg));
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl futures_codec::Encoder for Codec {
+    type Item = Message;
+    type Error = ConnectionError;
+
+    fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), ConnectionError> {
+        let command_size = item.command.encoded_len();
+        let metadata_size = item
+            .payload
+            .as_ref()
+            .map(|p| p.metadata.encoded_len())
+            .unwrap_or(0);
+        let payload_size = item.payload.as_ref().map(|p| p.data.len()).unwrap_or(0);
+        let header_size = if item.payload.is_some() { 18 } else { 8 };
+        // Total size does not include the size of the 'totalSize' field, so we subtract 4
+        let total_size = command_size + metadata_size + payload_size + header_size - 4;
+        let mut buf = Vec::with_capacity(total_size + 4);
+
+        // Simple command frame
+        buf.put_u32(total_size as u32);
+        buf.put_u32(command_size as u32);
+        item.command.encode(&mut buf)?;
+
+        // Payload command frame
+        if let Some(payload) = &item.payload {
+            buf.put_u16(0x0e01);
+
+            let crc_offset = buf.len();
+            buf.put_u32(0); // NOTE: Checksum (CRC32c). Overrwritten later to avoid copying.
+
+            let metdata_offset = buf.len();
+            buf.put_u32(metadata_size as u32);
+            payload.metadata.encode(&mut buf)?;
+            buf.put(&payload.data[..]);
+
+            let crc = crc32::checksum_castagnoli(&buf[metdata_offset..]);
+            let mut crc_buf: &mut [u8] = &mut buf[crc_offset..metdata_offset];
+            crc_buf.put_u32(crc);
+        }
+        if dst.remaining_mut() < buf.len() {
+            dst.reserve(buf.len());
+        }
+        dst.put_slice(&buf);
+        trace!("Encoder sending {} bytes", buf.len());
+        //        println!("Wrote message {:?}", item);
+        Ok(())
+    }
+}
+
+impl futures_codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -273,7 +273,7 @@ impl<Exe: Executor> Future for ProducerEngine<Exe> {
                                     }
                                 }
                             };
-                            tokio::spawn(f);
+                            Exe::spawn(Box::pin(f));
                             self.new_producers.insert(topic, Box::pin(rx));
                         }
                     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -304,28 +304,7 @@ pub struct TopicProducer {
 }
 
 impl TopicProducer {
-    /*pub fn new<S1, S2, E: Executor+'static>(
-        addr: S1,
-        topic: S2,
-        name: Option<String>,
-        auth: Option<Authentication>,
-        proxy_to_broker_url: Option<String>,
-        options: ProducerOptions,
-        executor: E,
-    ) -> impl Future<Output = Result<TopicProducer, Error>>
-    where
-        S1: Into<String>,
-        S2: Into<String>,
-    {
-        Connection::new(addr.into(), auth, proxy_to_broker_url, executor)
-            .map_err(|e| e.into())
-            .and_then(move |conn| {
-                TopicProducer::from_connection::<_>(Arc::new(conn), topic.into(), name, options)
-            })
-    }
-    */
-
-    pub async fn from_connection<Exe: PulsarExecutor, S: Into<String>>(
+    pub async fn from_connection<Exe: Executor, S: Into<String>>(
         connection: Arc<Connection>,
         topic: S,
         name: Option<String>,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -15,7 +15,7 @@ use rand;
 use crate::client::SerializeMessage;
 use crate::connection::{Connection, SerialId};
 use crate::error::ProducerError;
-use crate::executor::PulsarExecutor;
+use crate::executor::Executor;
 use crate::message::proto::{self, EncryptionKeys, Schema, CompressionType};
 use crate::message::BatchedMessage;
 use crate::{Error, Pulsar};
@@ -65,7 +65,7 @@ pub struct Producer {
 }
 
 impl Producer {
-    pub fn new<Exe: PulsarExecutor + ?Sized>(pulsar: Pulsar<Exe>, options: ProducerOptions) -> Producer {
+    pub fn new<Exe: Executor + ?Sized>(pulsar: Pulsar<Exe>, options: ProducerOptions) -> Producer {
         let (tx, rx) = unbounded();
         if let Err(_) = Exe::spawn(Box::pin(ProducerEngine {
             pulsar,
@@ -153,7 +153,7 @@ impl Producer {
     }
 }
 
-struct ProducerEngine<Exe: PulsarExecutor + ?Sized> {
+struct ProducerEngine<Exe: Executor + ?Sized> {
     pulsar: Pulsar<Exe>,
     inbound: Pin<Box<UnboundedReceiver<ProducerMessage>>>,
     producers: BTreeMap<String, Arc<TopicProducer>>,
@@ -161,7 +161,7 @@ struct ProducerEngine<Exe: PulsarExecutor + ?Sized> {
     producer_options: ProducerOptions,
 }
 
-impl<Exe: PulsarExecutor> Future for ProducerEngine<Exe> {
+impl<Exe: Executor> Future for ProducerEngine<Exe> {
     type Output = Result<(), ()>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -1,7 +1,7 @@
 use crate::connection::{Authentication, Connection};
 use crate::connection_manager::{BrokerAddress, ConnectionManager};
 use crate::error::ServiceDiscoveryError;
-use crate::executor:: PulsarExecutor;
+use crate::executor:: Executor;
 use crate::message::proto::{command_lookup_topic_response, CommandLookupTopicResponse};
 use futures::{future::try_join_all, FutureExt};
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -14,11 +14,11 @@ use url::Url;
 /// interacting with a cluster. It will automatically follow redirects
 /// or use a proxy, and aggregate broker connections
 #[derive(Clone)]
-pub struct ServiceDiscovery<Exe: PulsarExecutor + ?Sized> {
+pub struct ServiceDiscovery<Exe: Executor + ?Sized> {
     manager: Arc<ConnectionManager<Exe>>,
 }
 
-impl<Exe: PulsarExecutor> ServiceDiscovery<Exe> {
+impl<Exe: Executor> ServiceDiscovery<Exe> {
     pub async fn new(
         addr: SocketAddr,
         auth: Option<Authentication>,


### PR DESCRIPTION
first commit: remove the executor member, and instead get the executor statically (to do  `tokio::runtime::Handle::current().spawn(f)` with tokio and `task::spawn(f)` wih async-std).

@LucioFranco IIRC you did the initial work to make pulsar-rs generic over the executor (was that to support tokio 0.1 and tokio 0.2 in vector?). Will this change cause issues with the integration in vector?

From a user's point of view, the main change is this https://github.com/wyyerd/pulsar-rs/pull/88/files#diff-f5be2bf3fd69683200ad4f58e2550984R63

(and I'll add `new_tokio` an `new_async_std` methods to simplify that)