### PR TITLE
move message deserialization outside of the consumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ snap = { version = "1.0", optional = true }
 [dev-dependencies]
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
+env_logger = "0.7"
 
 [build-dependencies]
 prost-build = "0.6.0"

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -27,7 +27,7 @@ impl SerializeMessage for TestData {
 impl DeserializeMessage for TestData {
     type Output = Result<TestData, serde_json::Error>;
 
-    fn deserialize_message(payload: Payload) -> Self::Output {
+    fn deserialize_message(payload: &Payload) -> Self::Output {
         serde_json::from_slice(&payload.data)
     }
 }
@@ -102,7 +102,7 @@ fn main() {
         while let Some(res) = consumer.next().await {
             let msg = res.unwrap();
             consumer.ack(&msg);
-            let data = msg.payload.unwrap();
+            let data = msg.deserialize().unwrap();
             /*let Message { payload, ack, .. } = res.unwrap();
             ack.ack();
             let data = payload.unwrap();

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -1,12 +1,10 @@
 #[macro_use]
 extern crate serde;
-use log::{Record, Metadata, LevelFilter};
 use pulsar::{Consumer, Pulsar, TokioExecutor,
   message::Payload, SerializeMessage, DeserializeMessage, Error as PulsarError,
   message::proto::command_subscribe::SubType, producer,
   message::proto};
-use tokio::runtime::Runtime;
-use futures::StreamExt;
+use futures::TryStreamExt;
 
 #[derive(Serialize, Deserialize)]
 struct TestData {
@@ -32,43 +30,21 @@ impl DeserializeMessage for TestData {
     }
 }
 
-pub struct SimpleLogger;
-impl log::Log for SimpleLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        //metadata.level() <= Level::Info
-        true
-    }
+#[tokio::main]
+async fn main() -> Result<(), pulsar::Error> {
+    env_logger::init();
 
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            println!("{} {}\t{}\t{}", chrono::Utc::now(),
-            record.level(), record.module_path().unwrap(), record.args());
-        }
-    }
-    fn flush(&self) {
-        use std::io::Write;
-        std::io::stdout().flush().unwrap();
-    }
-}
-
-pub static TEST_LOGGER: SimpleLogger = SimpleLogger;
-
-fn main() {
-    let mut runtime = Runtime::new().unwrap();
-    let _ = log::set_logger(&TEST_LOGGER);
-    let _ = log::set_max_level(LevelFilter::Debug);
-
-    let producer = async {
-        let addr = "localhost";
-        let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
-        let producer = pulsar.create_producer("test", Some("my-producer".to_string()), producer::ProducerOptions {
-            schema: Some(proto::Schema {
-                      type_: proto::schema::Type::String as i32,
-                      ..Default::default()
-                    }),
+    let addr = "127.0.0.1:6650";
+    let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await?;
+    let producer = pulsar.create_producer("test", Some("my-producer".to_string()), producer::ProducerOptions {
+        schema: Some(proto::Schema {
+            type_: proto::schema::Type::String as i32,
             ..Default::default()
-        }).await.unwrap();
+        }),
+        ..Default::default()
+    }).await?;
 
+    tokio::task::spawn(async move {
         let mut counter = 0usize;
         loop {
             producer.send(
@@ -81,42 +57,32 @@ fn main() {
                 println!("sent {} messages", counter);
             }
         }
-    };
-    runtime.spawn(Box::pin(producer));
+    });
 
-    let consumer = async {
-        let addr = "localhost";
-        let pulsar: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await.unwrap();
+    let pulsar2: Pulsar<TokioExecutor> = Pulsar::new(addr, None).await?;
 
-        let mut consumer: Consumer<TestData> = pulsar
-            .consumer()
-            .with_topic("test")
-            .with_consumer_name("test_consumer")
-            .with_subscription_type(SubType::Exclusive)
-            .with_subscription("test_subscription")
-            .build()
-            .await
-            .unwrap();
+    let mut consumer: Consumer<TestData> = pulsar2
+        .consumer()
+        .with_topic("test")
+        .with_consumer_name("test_consumer")
+        .with_subscription_type(SubType::Exclusive)
+        .with_subscription("test_subscription")
+        .build()
+        .await?;
 
-        let mut counter = 0usize;
-        while let Some(res) = consumer.next().await {
-            let msg = res.unwrap();
-            consumer.ack(&msg);
-            let data = msg.deserialize().unwrap();
-            /*let Message { payload, ack, .. } = res.unwrap();
-            ack.ack();
-            let data = payload.unwrap();
-            */
-            if data.data.as_str() != "data" {
-                panic!("Unexpected payload: {}", &data.data);
-            }
-            counter += 1;
-            if counter %1000 == 0 {
-                println!("received {} messages", counter);
-            }
+    let mut counter = 0usize;
+    while let Some(msg) = consumer.try_next().await? {
+        consumer.ack(&msg)?;
+        let data = msg.deserialize().unwrap();
+        if data.data.as_str() != "data" {
+            panic!("Unexpected payload: {}", &data.data);
         }
-        // FIXME .timeout(Duration::from_secs(5))
-    };
+        counter += 1;
+        if counter %1000 == 0 {
+            println!("received {} messages", counter);
+        }
+    }
 
-    runtime.block_on(Box::pin(consumer));
+
+    Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,30 +18,22 @@ use crate::service_discovery::ServiceDiscovery;
 /// Helper trait for consumer deserialization
 pub trait DeserializeMessage {
     type Output: Sized;
-    fn deserialize_message(payload: Payload) -> Self::Output;
-}
-
-impl DeserializeMessage for Payload {
-    type Output = Self;
-
-    fn deserialize_message(payload: Payload) -> Self::Output {
-        payload
-    }
+    fn deserialize_message(payload: &Payload) -> Self::Output;
 }
 
 impl DeserializeMessage for Vec<u8> {
     type Output = Self;
 
-    fn deserialize_message(payload: Payload) -> Self::Output {
-        payload.data
+    fn deserialize_message(payload: &Payload) -> Self::Output {
+        payload.data.to_vec()
     }
 }
 
 impl DeserializeMessage for String {
     type Output = Result<String, FromUtf8Error>;
 
-    fn deserialize_message(payload: Payload) -> Self::Output {
-        String::from_utf8(payload.data)
+    fn deserialize_message(payload: &Payload) -> Self::Output {
+        String::from_utf8(payload.data.to_vec())
     }
 }
 


### PR DESCRIPTION
This is an attempt at making deserializing a bit easier to handle (types are easier to follow, no need to implement DeserializeMessage if we don't need it, etc). @stearnsc an opinion on this?

The basic idea is that instead of the consumer returning a message on which `DeserializeMessage::deserialize_message` was already called (and losing payload metadata at the same time), we separate the deserialize phase into a method on the message