### PR TITLE
Cleanup API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsar"
-version = "1.0.0"
+version = "1.0.0-alpha-2"
 edition = "2018"
 authors = [
     "Colin Stearns <cstearns@developers.wyyerd.com>",

--- a/examples/batching.rs
+++ b/examples/batching.rs
@@ -3,7 +3,7 @@ extern crate serde;
 use futures::{future::join_all, TryStreamExt};
 use pulsar::{
     message::proto, message::proto::command_subscribe::SubType, message::Payload, producer,
-    Consumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
+    TopicConsumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -79,7 +79,7 @@ async fn main() -> Result<(), pulsar::Error> {
         println!("receipts: {:?}", join_all(v).await);
     });
 
-    let mut consumer: Consumer<TestData> = pulsar
+    let mut consumer: TopicConsumer<TestData> = pulsar
         .consumer()
         .with_topic("test-batch-compression-snappy")
         .with_consumer_name("test_consumer")

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -2,7 +2,7 @@
 extern crate serde;
 use futures::TryStreamExt;
 use pulsar::{
-    message::proto::command_subscribe::SubType, message::Payload, Consumer, DeserializeMessage,
+    message::proto::command_subscribe::SubType, message::Payload, TopicConsumer, DeserializeMessage,
     Pulsar, TokioExecutor,
 };
 
@@ -26,7 +26,7 @@ async fn main() -> Result<(), pulsar::Error> {
     let addr = "pulsar://127.0.0.1:6650";
     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 
-    let mut consumer: Consumer<TestData> = pulsar
+    let mut consumer: TopicConsumer<TestData> = pulsar
         .consumer()
         .with_topic("non-persistent://public/default/test")
         .with_consumer_name("test_consumer")

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -2,7 +2,7 @@
 extern crate serde;
 use futures::TryStreamExt;
 use pulsar::{
-    message::proto::command_subscribe::SubType, message::Payload, Consumer, DeserializeMessage,
+    SubType, Payload, Consumer, DeserializeMessage,
     Pulsar, TokioExecutor,
 };
 

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -2,7 +2,7 @@
 extern crate serde;
 use futures::TryStreamExt;
 use pulsar::{
-    message::proto::command_subscribe::SubType, message::Payload, TopicConsumer, DeserializeMessage,
+    message::proto::command_subscribe::SubType, message::Payload, Consumer, DeserializeMessage,
     Pulsar, TokioExecutor,
 };
 
@@ -26,7 +26,7 @@ async fn main() -> Result<(), pulsar::Error> {
     let addr = "pulsar://127.0.0.1:6650";
     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 
-    let mut consumer: TopicConsumer<TestData> = pulsar
+    let mut consumer: Consumer<TestData, _> = pulsar
         .consumer()
         .with_topic("non-persistent://public/default/test")
         .with_consumer_name("test_consumer")

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -3,7 +3,7 @@ extern crate serde;
 use futures::TryStreamExt;
 use pulsar::{
     message::proto, message::proto::command_subscribe::SubType, message::Payload, producer,
-    TopicConsumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
+    Consumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -36,17 +36,17 @@ async fn main() -> Result<(), pulsar::Error> {
     let addr = "pulsar://127.0.0.1:6650";
     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
     let mut producer = pulsar
-        .create_producer(
-            "test",
-            Some("my-producer".to_string()),
-            producer::ProducerOptions {
-                schema: Some(proto::Schema {
-                    type_: proto::schema::Type::String as i32,
-                    ..Default::default()
-                }),
+        .producer()
+        .with_topic("test")
+        .with_name("my-producer")
+        .with_options(producer::ProducerOptions {
+            schema: Some(proto::Schema {
+                type_: proto::schema::Type::String as i32,
                 ..Default::default()
-            },
-        )
+            }),
+            ..Default::default()
+        })
+        .build()
         .await?;
 
     tokio::task::spawn(async move {
@@ -69,7 +69,7 @@ async fn main() -> Result<(), pulsar::Error> {
 
     let pulsar2: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 
-    let mut consumer: TopicConsumer<TestData> = pulsar2
+    let mut consumer: Consumer<TestData, _> = pulsar2
         .consumer()
         .with_topic("test")
         .with_consumer_name("test_consumer")

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -3,7 +3,7 @@ extern crate serde;
 use futures::TryStreamExt;
 use pulsar::{
     message::proto, message::proto::command_subscribe::SubType, message::Payload, producer,
-    Consumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
+    TopicConsumer, DeserializeMessage, Error as PulsarError, Pulsar, SerializeMessage, TokioExecutor,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -69,7 +69,7 @@ async fn main() -> Result<(), pulsar::Error> {
 
     let pulsar2: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 
-    let mut consumer: Consumer<TestData> = pulsar2
+    let mut consumer: TopicConsumer<TestData> = pulsar2
         .consumer()
         .with_topic("test")
         .with_consumer_name("test_consumer")

--- a/src/client.rs
+++ b/src/client.rs
@@ -241,7 +241,8 @@ impl<Exe: Executor> Pulsar<Exe> {
         MultiTopicConsumer::new(
             self.clone(),
             namespace.into(),
-            topic_regex,
+            Some(topic_regex),
+            None,
             subscription.into(),
             sub_type,
             topic_refresh,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -433,6 +433,7 @@ impl ConnectionSender {
 }
 
 pub struct Connection {
+    id: i64,
     url: Url,
     sender: ConnectionSender,
 }
@@ -500,7 +501,8 @@ impl Connection {
         )
         .await?;
 
-        Ok(Connection { url, sender })
+        let id = rand::random();
+        Ok(Connection { id, url, sender })
     }
 
     async fn prepare_stream<Exe: Executor + ?Sized>(
@@ -660,6 +662,10 @@ impl Connection {
         );
 
         Ok(sender)
+    }
+
+    pub fn id(&self) -> i64 {
+        self.id
     }
 
     pub fn error(&self) -> Option<ConnectionError> {

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -775,6 +775,11 @@ pub struct Set<T>(pub T);
 
 pub struct Unset;
 
+pub enum MultiTopic {
+    Regex(Regex),
+    List(Vec<String>),
+}
+
 pub struct ConsumerBuilder<'a, Topic, Subscription, SubscriptionType, Exe: Executor + ?Sized> {
     pulsar: &'a Pulsar<Exe>,
     topic: Topic,
@@ -824,7 +829,7 @@ impl<'a, Exe: Executor> ConsumerBuilder<'a, Set<String>, Set<String>, Set<SubTyp
     }
 }
 
-impl<'a, Exe: Executor> ConsumerBuilder<'a, Set<Regex>, Set<String>, Set<SubType>, Exe> {
+impl<'a, Exe: Executor> ConsumerBuilder<'a, Set<MultiTopic>, Set<String>, Set<SubType>, Exe> {
     pub fn build<T: DeserializeMessage>(self) -> MultiTopicConsumer<T, Exe> {
         let ConsumerBuilder {
             pulsar,
@@ -853,10 +858,17 @@ impl<'a, Exe: Executor> ConsumerBuilder<'a, Set<Regex>, Set<String>, Set<SubType
         let namespace = namespace.unwrap_or_else(|| "public/default".to_owned());
         let topic_refresh = topic_refresh.unwrap_or_else(|| Duration::from_secs(30));
 
-        pulsar.create_multi_topic_consumer(
-            topic,
-            subscription,
+        let (topic_regex, topic_list) = match topic {
+            MultiTopic::Regex(regex) => (Some(regex), None),
+            MultiTopic::List(list) => (None, Some(list)),
+        };
+
+        MultiTopicConsumer::new(
+            pulsar.clone(),
             namespace,
+            topic_regex,
+            topic_list,
+            subscription,
             sub_type,
             topic_refresh,
             unacked_message_resend_delay,
@@ -909,13 +921,40 @@ impl<'a, Subscription, SubscriptionType, Exe: Executor + ?Sized>
         }
     }
 
+    pub fn with_topics<S: AsRef<str>>(
+        self,
+        topics: &[S]
+    ) -> ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe> {
+        let topics = topics.into_iter().map(|t| t.as_ref().into()).collect();
+        ConsumerBuilder {
+            pulsar: self.pulsar,
+            topic: Set(MultiTopic::List(topics)),
+            subscription: self.subscription,
+            subscription_type: self.subscription_type,
+            consumer_id: self.consumer_id,
+            consumer_name: self.consumer_name,
+            consumer_options: self.consumer_options,
+            batch_size: self.batch_size,
+            namespace: self.namespace,
+            topic_refresh: self.topic_refresh,
+            unacked_message_resend_delay: self.unacked_message_resend_delay,
+        }
+    }
+
     pub fn multi_topic(
         self,
         regex: Regex,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
+    ) -> ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe> {
+        self.with_topic_regex(regex)
+    }
+
+    pub fn with_topic_regex(
+        self,
+        regex: Regex,
+    ) -> ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
-            topic: Set(regex),
+            topic: Set(MultiTopic::Regex(regex)),
             subscription: self.subscription,
             subscription_type: self.subscription_type,
             consumer_id: self.consumer_id,
@@ -979,12 +1018,12 @@ impl<'a, Topic, Subscription, Exe: Executor + ?Sized>
 }
 
 impl<'a, Subscription, SubscriptionType, Exe: Executor + ?Sized>
-    ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe>
+    ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe>
 {
     pub fn with_namespace<S: Into<String>>(
         self,
         namespace: S,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
+    ) -> ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: self.topic,
@@ -1004,7 +1043,7 @@ impl<'a, Subscription, SubscriptionType, Exe: Executor + ?Sized>
     pub fn with_topic_refresh(
         self,
         refresh_interval: Duration,
-    ) -> ConsumerBuilder<'a, Set<Regex>, Subscription, SubscriptionType, Exe> {
+    ) -> ConsumerBuilder<'a, Set<MultiTopic>, Subscription, SubscriptionType, Exe> {
         ConsumerBuilder {
             pulsar: self.pulsar,
             topic: self.topic,
@@ -1090,7 +1129,8 @@ pub struct ConsumerState {
 /// A consumer that can subscribe on multiple topics, from a rege matching topic names
 pub struct MultiTopicConsumer<T: DeserializeMessage, Exe: Executor> {
     namespace: String,
-    topic_regex: Regex,
+    topic_regex: Option<Regex>,
+    topic_list: Option<Vec<String>>,
     pulsar: Pulsar<Exe>,
     unacked_message_resend_delay: Option<Duration>,
     dead_letter_policy: Option<DeadLetterPolicy>,
@@ -1110,7 +1150,8 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     pub fn new<S1, S2>(
         pulsar: Pulsar<Exe>,
         namespace: S1,
-        topic_regex: Regex,
+        topic_regex: Option<Regex>,
+        topic_list: Option<Vec<String>>,
         subscription: S2,
         sub_type: SubType,
         topic_refresh: Duration,
@@ -1125,6 +1166,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         MultiTopicConsumer {
             namespace: namespace.into(),
             topic_regex,
+            topic_list,
             pulsar,
             unacked_message_resend_delay,
             dead_letter_policy,
@@ -1191,6 +1233,69 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             self.consumers.remove(topic);
         }
         self.send_state();
+    }
+
+    fn update_topics(&mut self) {
+        let regex = self.topic_regex.clone();
+        let topic_list =  self.topic_list.clone();
+        let pulsar = self.pulsar.clone();
+        let namespace = self.namespace.clone();
+        let subscription = self.subscription.clone();
+        let sub_type = self.sub_type;
+        let existing_topics: BTreeSet<String> = self.consumers.keys().cloned().collect();
+        let options = self.options.clone();
+        let unacked_message_resend_delay = self.unacked_message_resend_delay;
+        let dead_letter_policy = self.dead_letter_policy.clone();
+
+        let new_consumers = Box::pin(async move {
+            let topics: Vec<String> = pulsar
+                .get_topics_of_namespace(namespace.clone(), proto::get_topics::Mode::All)
+                .await?;
+            trace!("fetched topics: {:?}", &topics);
+
+            let mut v = vec![];
+            let new_topics = topics.into_iter()
+                .filter(move |topic| {
+                    if existing_topics.contains(topic) {
+                        return false;
+                    }
+                    let prefix_idx = topic.rfind("/")
+                        .map(|i| i + 1)
+                        .unwrap_or(0);
+
+                    let trimmed_topic = topic[prefix_idx..].to_string();
+                    if let Some(regex) = &regex {
+                        if regex.is_match(&topic) || regex.is_match(&trimmed_topic) {
+                            return true;
+                        }
+                    }
+                    if let Some(topic_list) = &topic_list {
+                        if topic_list.contains(topic) || topic_list.contains(&trimmed_topic) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+            for topic in new_topics {
+                trace!("creating consumer for topic {}", topic);
+                //let pulsar = pulsar.clone();
+                let subscription = subscription.clone();
+                v.push(pulsar.create_consumer(
+                    topic,
+                    subscription,
+                    sub_type,
+                    None,
+                    None,
+                    None,
+                    unacked_message_resend_delay,
+                    dead_letter_policy,
+                    options.clone(),
+                ));
+            }
+
+            try_join_all(v).await
+        });
+        self.new_consumers = Some(new_consumers);
     }
 
     pub async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
@@ -1268,45 +1373,7 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
         }
 
         if let Poll::Ready(Some(_)) = self.refresh.as_mut().poll_next(cx) {
-            let regex = self.topic_regex.clone();
-            let pulsar = self.pulsar.clone();
-            let namespace = self.namespace.clone();
-            let subscription = self.subscription.clone();
-            let sub_type = self.sub_type;
-            let existing_topics: BTreeSet<String> = self.consumers.keys().cloned().collect();
-            let options = self.options.clone();
-            let unacked_message_resend_delay = self.unacked_message_resend_delay;
-            let dead_letter_policy = self.dead_letter_policy.clone();
-
-            let new_consumers = Box::pin(async move {
-                let topics: Vec<String> = pulsar
-                    .get_topics_of_namespace(namespace.clone(), proto::get_topics::Mode::All)
-                    .await?;
-                trace!("fetched topics: {:?}", &topics);
-
-                let mut v = vec![];
-                for topic in topics.into_iter().filter(move |topic| {
-                    !existing_topics.contains(topic) && regex.is_match(topic.as_str())
-                }) {
-                    trace!("creating consumer for topic {}", topic);
-                    //let pulsar = pulsar.clone();
-                    let subscription = subscription.clone();
-                    v.push(pulsar.create_consumer(
-                        topic,
-                        subscription,
-                        sub_type,
-                        None,
-                        None,
-                        None,
-                        unacked_message_resend_delay,
-                        dead_letter_policy.clone(),
-                        options.clone(),
-                    ));
-                }
-
-                try_join_all(v).await
-            });
-            self.new_consumers = Some(new_consumers);
+            self.update_topics();
             return self.poll_next(cx);
         }
 
@@ -1466,7 +1533,9 @@ mod tests {
 
             let mut consumer: MultiTopicConsumer<TestData, _> = client
                 .consumer()
-                .multi_topic(Regex::new("mt_test_[ab]").unwrap())
+                // TODO extract out test functionality to test both multi-topic cases
+                // .with_topics(&["mt_test_a", "mt_test_b"])
+                .with_topic_regex(Regex::new("mt_test_[ab]").unwrap())
                 .with_namespace(namespace)
                 .with_subscription("test_sub")
                 .with_subscription_type(SubType::Shared)

--- a/src/error.rs
+++ b/src/error.rs
@@ -318,7 +318,7 @@ impl std::error::Error for ServiceDiscoveryError {
 }
 
 #[derive(Clone)]
-pub struct SharedError {
+pub(crate) struct SharedError {
     error_set: Arc<AtomicBool>,
     error: Arc<Mutex<Option<ConnectionError>>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub use executor::Executor;
 pub use executor::TokioExecutor;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{MultiTopicProducer, Producer, ProducerOptions};
-pub use message::proto::{self, CommandSendReceipt};
+pub use message::{Payload, proto::{self, CommandSendReceipt}};
 
 mod client;
 mod connection;
@@ -167,7 +167,7 @@ mod connection_manager;
 pub mod consumer;
 pub mod error;
 mod executor;
-mod message;
+pub mod message;
 pub mod producer;
 mod service_discovery;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub use executor::Executor;
 pub use executor::TokioExecutor;
 pub use message::proto::command_subscribe::SubType;
 pub use producer::{MultiTopicProducer, Producer, ProducerOptions};
+pub use message::proto::{self, CommandSendReceipt};
 
 mod client;
 mod connection;
@@ -166,7 +167,7 @@ mod connection_manager;
 pub mod consumer;
 pub mod error;
 mod executor;
-pub mod message;
+mod message;
 pub mod producer;
 mod service_discovery;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! extern crate serde;
 //! use futures::TryStreamExt;
 //! use pulsar::{
-//!     message::proto::command_subscribe::SubType, message::Payload, TopicConsumer, DeserializeMessage,
+//!     message::proto::command_subscribe::SubType, message::Payload, Consumer, DeserializeMessage,
 //!     Pulsar, TokioExecutor,
 //! };
 //!
@@ -103,7 +103,7 @@
 //!     let addr = "pulsar://127.0.0.1:6650";
 //!     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 //!
-//!     let mut consumer: TopicConsumer<TestData> = pulsar
+//!     let mut consumer: Consumer<TestData, _> = pulsar
 //!         .consumer()
 //!         .with_topic("test")
 //!         .with_consumer_name("test_consumer")
@@ -172,37 +172,36 @@ mod service_discovery;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::time::{Duration, Instant};
+    use log::{LevelFilter, Metadata, Record};
+    use futures::{future::try_join_all, StreamExt};
 
-    use futures::{StreamExt, TryStreamExt};
     #[cfg(feature = "tokio-runtime")]
-    use tokio;
-    #[cfg(feature = "tokio-runtime")]
-    use tokio::runtime::Runtime;
+    use tokio::time::timeout;
 
-    use message::proto::command_subscribe::SubType;
-
-    use crate::client::SerializeMessage;
     #[cfg(feature = "tokio-runtime")]
     use crate::executor::TokioExecutor;
+
+    use crate::client::SerializeMessage;
     use crate::message::Payload;
     use crate::Error as PulsarError;
+    use crate::consumer::Message;
+    use crate::message::proto::command_subscribe::SubType;
 
     use super::*;
-    use nom::lib::std::collections::BTreeSet;
-    use rand::distributions::Alphanumeric;
-    use rand::Rng;
-    use std::collections::BTreeMap;
+
 
     #[derive(Debug, Serialize, Deserialize)]
     struct TestData {
+        pub id: u64,
         pub data: String,
     }
 
-    impl SerializeMessage for TestData {
+    impl<'a> SerializeMessage for &'a TestData {
         fn serialize_message(input: Self) -> Result<producer::Message, PulsarError> {
             let payload =
-                serde_json::to_vec(&input).map_err(|e| PulsarError::Custom(e.to_string()))?;
+                serde_json::to_vec(input).map_err(|e| PulsarError::Custom(e.to_string()))?;
             Ok(producer::Message {
                 payload,
                 ..Default::default()
@@ -261,7 +260,6 @@ mod tests {
         }
     }
 
-    use log::{LevelFilter, Metadata, Record};
     pub struct SimpleLogger {
         pub tag: &'static str,
     }
@@ -288,286 +286,199 @@ mod tests {
 
     pub static TEST_LOGGER: SimpleLogger = SimpleLogger { tag: "" };
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "tokio-runtime")]
-    fn round_trip() {
-        let mut runtime = Runtime::new().unwrap();
+    async fn round_trip() {
         let _ = log::set_logger(&TEST_LOGGER);
         let _ = log::set_max_level(LevelFilter::Debug);
-
-        let f = async {
-            let addr = "pulsar://127.0.0.1:6650";
-            let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
-
-            let mut consumer: TopicConsumer<TestData> = pulsar
-                .consumer()
-                .with_topic("test")
-                .with_consumer_name("test_consumer")
-                .with_subscription_type(SubType::Exclusive)
-                .with_subscription("test_subscription")
-                .build()
-                .await
-                .unwrap();
-
-            info!("consumer created");
-
-            let mut producer = pulsar.producer().with_topic("test").build().await.unwrap();
-            info!("producer created");
-
-            info!("will send message");
-            for _ in 0u16..5000 {
-                producer
-                    .send(TestData {
-                        data: "data".to_string(),
-                    })
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap();
-            }
-
-            info!("sent");
-            //let mut stream = consumer.take(5000);
-            let mut count = 0usize;
-            while let Ok(Some(msg)) = consumer.try_next().await {
-                //let res =  consumer.next().await.unwrap();
-                //let msg = res.unwrap();
-                consumer.ack(&msg).await.unwrap();
-                let data = msg.deserialize().unwrap();
-                if data.data.as_str() != "data" {
-                    panic!("Unexpected payload: {}", &data.data);
-                }
-
-                count += 1;
-
-                if count % 500 == 0 {
-                    info!("messages received: {}", count);
-                }
-                if count == 5000 {
-                    break;
-                }
-            }
-            // FIXME .timeout(Duration::from_secs(5))
-        };
-
-        runtime.block_on(Box::pin(f));
-    }
-
-    #[test]
-    #[cfg(feature = "tokio-runtime")]
-    fn unsized_data() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
-        let mut runtime = Runtime::new().unwrap();
-
-        let f = async {
-            let addr = "pulsar://127.0.0.1:6650";
-            let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
-            let mut producer = pulsar.create_multi_topic_producer(None);
-
-            // test &str
-            {
-                let topic = "test_unsized_data_str";
-                let send_data = "some unsized data";
-
-                let mut consumer = pulsar
-                    .consumer()
-                    .with_topic(topic)
-                    .with_subscription_type(SubType::Exclusive)
-                    .with_subscription("test_subscription")
-                    .build::<String>()
-                    .await
-                    .unwrap();
-
-                producer
-                    .send(topic, send_data.to_string())
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap();
-
-                let msg = consumer.next().await.unwrap().unwrap();
-                consumer.ack(&msg).await.unwrap();
-
-                let data = msg.deserialize().unwrap();
-                if data.as_str() != send_data {
-                    panic!("Unexpected payload in &str test: {}", &data);
-                }
-                //FIXME .timeout(Duration::from_secs(1))
-            }
-
-            // test &[u8]
-            {
-                let topic = "test_unsized_data_bytes";
-                let send_data: &[u8] = &[0, 1, 2, 3];
-
-                let mut consumer = pulsar
-                    .consumer()
-                    .with_topic(topic)
-                    .with_subscription_type(SubType::Exclusive)
-                    .with_subscription("test_subscription")
-                    .build::<Vec<u8>>()
-                    .await
-                    .unwrap();
-
-                producer
-                    .send(topic, send_data.to_vec())
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap();
-
-                let msg = consumer.next().await.unwrap().unwrap();
-                consumer.ack(&msg).await.unwrap();
-                let data = msg.deserialize();
-                if data.as_slice() != send_data {
-                    panic!("Unexpected payload in &[u8] test: {:?}", &data);
-                }
-            }
-        };
-
-        runtime.block_on(Box::pin(f));
-    }
-
-    #[test]
-    #[ignore]
-    #[cfg(feature = "tokio-runtime")]
-    fn redelivery() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
-        let runtime = Runtime::new().unwrap();
 
         let addr = "pulsar://127.0.0.1:6650";
-        let (tx, rx) = std::sync::mpsc::channel();
+        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
 
-        let mut seen = BTreeSet::new();
-        let start = Instant::now();
-        let resend_delay = Duration::from_secs(4);
+        // random topic to better allow multiple test runs while debugging
+        let topic = format!("test_{}", rand::random::<u16>());
 
-        let message_count = 10;
-        let f = async move {
-            let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+        let mut producer = pulsar.producer().with_topic(&topic).build().await.unwrap();
+        info!("producer created");
 
-            let topic: String = std::iter::repeat(())
-                .map(|()| rand::thread_rng().sample(Alphanumeric))
-                .take(7)
-                .collect();
-            let mut producer = pulsar
-                .create_producer(&topic, None, ProducerOptions::default())
+        let message_ids: BTreeSet<u64> = (0..100).collect();
+
+        info!("will send message");
+        let mut sends = Vec::new();
+        for &id in &message_ids {
+            let message = TestData {
+                data: "data".to_string(),
+                id,
+            };
+            sends.push(producer.send(&message).await.unwrap());
+        }
+        try_join_all(sends).await.unwrap();
+
+        info!("sent");
+
+        let mut consumer: Consumer<TestData, _> = pulsar
+            .consumer()
+            .with_topic(&topic)
+            .with_consumer_name("test_consumer")
+            .with_subscription_type(SubType::Exclusive)
+            .with_subscription("test_subscription")
+            .with_options(ConsumerOptions {
+                initial_position: Some(1),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        info!("consumer created");
+
+        let topics = consumer.topics();
+        debug!("consumer connected to {:?}", topics);
+        assert_eq!(topics.len(), 1);
+        assert!(topics[0].ends_with(&topic));
+
+        let mut received = BTreeSet::new();
+        while let Ok(Some(msg)) = timeout(Duration::from_secs(10), consumer.next()).await {
+            let msg: Message<TestData> = msg.unwrap();
+            received.insert(msg.deserialize().unwrap().id);
+            consumer.ack(&msg).await.unwrap();
+            if received.len() == message_ids.len() {
+                break;
+            }
+        }
+        assert_eq!(received.len(), message_ids.len());
+        assert_eq!(received, message_ids);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "tokio-runtime")]
+    async fn unsized_data() {
+        let _ = log::set_logger(&TEST_LOGGER);
+        let _ = log::set_max_level(LevelFilter::Debug);
+
+        let addr = "pulsar://127.0.0.1:6650";
+        let test_id: u16 = rand::random();
+        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+
+        // test &str
+        {
+            let topic = format!("test_unsized_data_str_{}", test_id);
+            let send_data = "some unsized data";
+
+            pulsar
+                .send(&topic, send_data.to_string())
+                .await
+                .unwrap()
                 .await
                 .unwrap();
 
-            let mut consumer: TopicConsumer<TestData> = pulsar
+            let mut consumer = pulsar
                 .consumer()
                 .with_topic(&topic)
-                .with_consumer_name("test_consumer")
                 .with_subscription_type(SubType::Exclusive)
                 .with_subscription("test_subscription")
-                .with_unacked_message_resend_delay(Some(resend_delay))
-                .build()
+                .with_options(ConsumerOptions {
+                    initial_position: Some(1),
+                    ..Default::default()
+                })
+                .build::<String>()
                 .await
                 .unwrap();
 
-            for i in 0u8..message_count {
-                producer
-                    .send(TestData {
-                        data: i.to_string(),
-                    })
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap();
-            }
+            let msg = timeout(Duration::from_secs(1), consumer.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            consumer.ack(&msg).await.unwrap();
 
-            let mut count = 0usize;
-            while let Some(res) = consumer.next().await {
-                let message = res.unwrap();
-                let data = message.deserialize().unwrap();
-                tx.send(data.data.clone()).unwrap();
-                if !seen.contains(&data.data) {
-                    seen.insert(data.data.clone());
-                } else {
-                    //ack the second time around
-                    consumer.ack(&message).await.unwrap();
-                }
-
-                count += 1;
-                if count == message_count as usize * 2 {
-                    break;
-                }
-            }
-            //FIXME .timeout(Duration::from_secs(15))
-        };
-
-        runtime.spawn(Box::pin(f));
-
-        let mut counts = BTreeMap::new();
-
-        let timeout = Instant::now() + Duration::from_secs(2);
-        let mut read_count = 0;
-
-        while read_count < message_count {
-            if let Ok(data) = rx.try_recv() {
-                read_count += 1;
-                *counts.entry(data).or_insert(0) += 1;
-            } else {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            if Instant::now() > timeout {
-                panic!("timed out waiting for messages to be read");
+            let data = msg.deserialize().unwrap();
+            if data.as_str() != send_data {
+                panic!("Unexpected payload in &str test: {}", &data);
             }
         }
 
-        //check all messages we received are correct
-        (0..message_count).for_each(|i| {
-            let count = counts.get(&i.to_string());
-            if counts.get(&i.to_string()) != Some(&1) {
-                println!(
-                    "Expected {} count to be 1, found {}",
-                    i,
-                    count.cloned().unwrap_or(0)
-                );
-                panic!("{:?}", counts);
-            }
-        });
-        let mut redelivery_start = None;
+        // test &[u8]
+        {
+            let topic = format!("test_unsized_data_bytes_{}", test_id);
+            let send_data: &[u8] = &[0, 1, 2, 3];
 
-        let timeout = Instant::now() + resend_delay + Duration::from_secs(4);
-        while read_count < 2 * message_count {
-            if let Ok(data) = rx.try_recv() {
-                if redelivery_start.is_none() {
-                    redelivery_start = Some(Instant::now());
-                }
-                read_count += 1;
-                *counts.entry(data).or_insert(0) += 1;
-            } else {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            if Instant::now() > timeout {
-                println!("{:?}", counts);
-                panic!("timed out waiting for messages to be read");
+            pulsar
+                .send(&topic, send_data.to_vec())
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+
+            let mut consumer = pulsar
+                .consumer()
+                .with_topic(&topic)
+                .with_subscription_type(SubType::Exclusive)
+                .with_subscription("test_subscription")
+                .with_options(ConsumerOptions {
+                    initial_position: Some(1),
+                    ..Default::default()
+                })
+                .build::<Vec<u8>>()
+                .await
+                .unwrap();
+
+            let msg: Message<Vec<u8>> = timeout(Duration::from_secs(1), consumer.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            consumer.ack(&msg).await.unwrap();
+            let data = msg.deserialize();
+            if data.as_slice() != send_data {
+                panic!("Unexpected payload in &[u8] test: {:?}", &data);
             }
         }
-        let redelivery_start = redelivery_start.unwrap();
-        let expected_redelivery_start = start + resend_delay;
-        println!(
-            "start: 0ms, delay: {}ms, redelivery_start: {}ms, expected_redelivery: {}ms",
-            resend_delay.as_millis(),
-            (redelivery_start - start).as_millis(),
-            (expected_redelivery_start - start).as_millis()
-        );
-        assert!(redelivery_start > expected_redelivery_start - Duration::from_secs(1));
-        assert!(redelivery_start < expected_redelivery_start + Duration::from_secs(1));
-        (0u8..message_count).for_each(|i| {
-            let count = counts.get(&i.to_string());
-            if count != Some(&2) {
-                println!(
-                    "Expected {} count to be 2, found {}",
-                    i,
-                    count.cloned().unwrap_or(0)
-                );
-                panic!("{:?}", counts);
-            }
-        });
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "tokio-runtime")]
+    async fn redelivery() {
+        let _ = log::set_logger(&TEST_LOGGER);
+        let _ = log::set_max_level(LevelFilter::Debug);
+
+        let addr = "pulsar://127.0.0.1:6650";
+        let topic = format!("test_redelivery_{}", rand::random::<u16>());
+
+        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+        pulsar
+            .send(&topic, String::from("data"))
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+
+        let mut consumer: Consumer<String, _> = pulsar
+            .consumer()
+            .with_topic(topic)
+            .with_unacked_message_resend_delay(Some(Duration::from_millis(100)))
+            .with_options(ConsumerOptions {
+                initial_position: Some(1),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let _first_receipt = timeout(Duration::from_secs(2), consumer.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let first_received = Instant::now();
+        let second_receipt = timeout(Duration::from_secs(2), consumer.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let redelivery = first_received.elapsed();
+        consumer.ack(&second_receipt).await.unwrap();
+
+        assert!(redelivery < Duration::from_secs(1));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! extern crate serde;
 //! use futures::TryStreamExt;
 //! use pulsar::{
-//!     message::proto::command_subscribe::SubType, message::Payload, Consumer, DeserializeMessage,
+//!     message::proto::command_subscribe::SubType, message::Payload, TopicConsumer, DeserializeMessage,
 //!     Pulsar, TokioExecutor,
 //! };
 //!
@@ -103,7 +103,7 @@
 //!     let addr = "pulsar://127.0.0.1:6650";
 //!     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
 //!
-//!     let mut consumer: Consumer<TestData> = pulsar
+//!     let mut consumer: TopicConsumer<TestData> = pulsar
 //!         .consumer()
 //!         .with_topic("test")
 //!         .with_consumer_name("test_consumer")
@@ -150,7 +150,7 @@ extern crate serde;
 pub use client::{DeserializeMessage, Pulsar, SerializeMessage};
 pub use connection::Authentication;
 pub use connection_manager::{BackOffOptions, BrokerAddress, TlsOptions};
-pub use consumer::{Consumer, ConsumerOptions, ConsumerState, MultiTopicConsumer};
+pub use consumer::{Consumer, ConsumerBuilder, ConsumerOptions};
 pub use error::Error;
 #[cfg(feature = "async-std-runtime")]
 pub use executor::AsyncStdExecutor;
@@ -299,7 +299,7 @@ mod tests {
             let addr = "pulsar://127.0.0.1:6650";
             let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
 
-            let mut consumer: Consumer<TestData> = pulsar
+            let mut consumer: TopicConsumer<TestData> = pulsar
                 .consumer()
                 .with_topic("test")
                 .with_consumer_name("test_consumer")
@@ -457,7 +457,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let mut consumer: Consumer<TestData> = pulsar
+            let mut consumer: TopicConsumer<TestData> = pulsar
                 .consumer()
                 .with_topic(&topic)
                 .with_consumer_name("test_consumer")

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,5 +1,6 @@
 //! Message publication
 use futures::channel::oneshot;
+use futures::future::try_join_all;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::io::Write;
 use std::sync::{Arc, Mutex};
@@ -8,12 +9,32 @@ use crate::client::SerializeMessage;
 use crate::connection::{Connection, SerialId};
 use crate::error::{ConnectionError, ProducerError};
 use crate::executor::Executor;
-use crate::message::proto::{self, CompressionType, EncryptionKeys, Schema};
+use crate::message::proto::{self, CommandSendReceipt, CompressionType, EncryptionKeys, Schema};
 use crate::message::BatchedMessage;
 use crate::{Error, Pulsar};
+use futures::task::{Context, Poll};
+use futures::Future;
+use tokio::macros::support::Pin;
 
 type ProducerId = u64;
 type ProducerName = String;
+
+pub struct SendFuture(pub(crate) oneshot::Receiver<Result<CommandSendReceipt, Error>>);
+
+impl Future for SendFuture {
+    type Output = Result<CommandSendReceipt, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.0).poll(cx) {
+            Poll::Ready(Ok(r)) => Poll::Ready(r),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(ProducerError::Custom(
+                "producer unexpectedly disconnected".into(),
+            )
+            .into())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
 
 /// message data that will be sent on a topic
 ///
@@ -115,37 +136,29 @@ impl<Exe: Executor + ?Sized> MultiTopicProducer<Exe> {
         &mut self,
         topic: S,
         message: T,
-    ) -> Result<oneshot::Receiver<proto::CommandSendReceipt>, Error> {
-        let topic = topic.into();
-        match T::serialize_message(message) {
-            Ok(message) => self.send_message(topic, message.into()).await,
-            Err(e) => Err(e),
-        }
-    }
-
-    async fn send_message<S: Into<String>>(
-        &mut self,
-        topic: S,
-        message: ProducerMessage,
-    ) -> Result<oneshot::Receiver<proto::CommandSendReceipt>, Error> {
+    ) -> Result<SendFuture, Error> {
+        let message = T::serialize_message(message)?;
         let topic = topic.into();
         if !self.producers.contains_key(&topic) {
             let producer = self
                 .client
-                .create_producer(&topic, None, self.options.clone())
+                .producer()
+                .with_topic(&topic)
+                .with_options(self.options.clone())
+                .build()
                 .await?;
             self.producers.insert(topic.clone(), producer);
         }
 
         let producer = self.producers.get_mut(&topic).unwrap();
-        producer.send_raw(message).await
+        producer.send(message).await
     }
 
     pub async fn send_all<'a, 'b, T, S, I>(
         &mut self,
         topic: S,
         messages: I,
-    ) -> Result<Vec<oneshot::Receiver<proto::CommandSendReceipt>>, Error>
+    ) -> Result<Vec<SendFuture>, Error>
     where
         'b: 'a,
         T: 'b + SerializeMessage + Sized,
@@ -153,28 +166,154 @@ impl<Exe: Executor + ?Sized> MultiTopicProducer<Exe> {
         S: Into<String>,
     {
         let topic = topic.into();
+        let mut sends = Vec::new();
+        for msg in messages {
+            sends.push(self.send(&topic, msg).await);
+        }
         // TODO determine whether to keep this approach or go with the partial send, but more mem friendly lazy approach.
         // serialize all messages before sending to avoid a partial send
-        match messages
-            .into_iter()
-            .map(|m| T::serialize_message(m))
-            .collect::<Result<Vec<_>, _>>()
-        {
-            Ok(messages) => {
-                let mut v = vec![];
-                for m in messages.into_iter() {
-                    v.push(self.send_message(topic.clone(), m.into()).await?);
-                }
-
-                Ok(v)
-            }
-            Err(e) => Err(e),
+        if sends.iter().all(|s| s.is_ok()) {
+            Ok(sends.into_iter().map(|s| s.unwrap()).collect())
+        } else {
+            Err(ProducerError::PartialSend(sends).into())
         }
     }
 }
 
-/// a producer is used to publish messages on a topic
 pub struct Producer<Exe: Executor + ?Sized> {
+    inner: ProducerInner<Exe>,
+}
+
+impl<Exe: Executor + ?Sized> Producer<Exe> {
+    pub fn builder(pulsar: &Pulsar<Exe>) -> ProducerBuilder<Exe> {
+        ProducerBuilder::new(&pulsar)
+    }
+
+    pub fn topic(&self) -> &str {
+        match &self.inner {
+            ProducerInner::Single(p) => p.topic(),
+            ProducerInner::Partitioned(p) => &p.topic,
+        }
+    }
+
+    pub fn partitions(&self) -> Vec<String> {
+        match &self.inner {
+            ProducerInner::Single(p) => vec![p.topic().to_owned()],
+            ProducerInner::Partitioned(p) => {
+                p.producers.iter().map(|p| p.topic().to_owned()).collect()
+            }
+        }
+    }
+
+    pub fn options(&self) -> &ProducerOptions {
+        match &self.inner {
+            ProducerInner::Single(p) => p.options(),
+            ProducerInner::Partitioned(p) => &p.options,
+        }
+    }
+
+    pub fn create_message(&mut self) -> MessageBuilder<(), Exe> {
+        MessageBuilder::new(self)
+    }
+
+    pub async fn check_connection(&self) -> Result<(), Error> {
+        match &self.inner {
+            ProducerInner::Single(p) => p.check_connection().await,
+            ProducerInner::Partitioned(p) => {
+                try_join_all(p.producers.iter().map(|p| p.check_connection()))
+                    .await
+                    .map(drop)
+            }
+        }
+    }
+
+    /// sends a message
+    ///
+    /// this function returns a `SendFuture` because the receipt can come long after
+    /// this function was called, for various reasons:
+    /// - the message was sent successfully but Pulsar did not send the receipt yet
+    /// - the producer is batching messages, so this function must return immediately,
+    /// and the receipt will come when the batched messages are actually sent
+    ///
+    /// Usage:
+    ///
+    /// ```rust,ignore
+    /// let f1 = producer.send("hello").await?;
+    /// let f2 = producer.send("world").await?;
+    /// let receipt1 = f.await?;
+    /// let receipt2 = f.await?;
+    /// ```
+    pub async fn send<T: SerializeMessage + Sized>(
+        &mut self,
+        message: T,
+    ) -> Result<SendFuture, Error> {
+        match &mut self.inner {
+            ProducerInner::Single(p) => p.send(message).await,
+            ProducerInner::Partitioned(p) => p.next().send(message).await,
+        }
+    }
+
+    pub async fn send_all<T, I>(&mut self, messages: I) -> Result<Vec<SendFuture>, Error>
+    where
+        T: SerializeMessage,
+        I: IntoIterator<Item = T>,
+    {
+        let producer = match &mut self.inner {
+            ProducerInner::Single(p) => p,
+            ProducerInner::Partitioned(p) => p.next(),
+        };
+        let mut sends = Vec::new();
+        for message in messages {
+            sends.push(producer.send(message).await);
+        }
+        if sends.iter().all(|s| s.is_ok()) {
+            Ok(sends.into_iter().map(|s| s.unwrap()).collect())
+        } else {
+            Err(ProducerError::PartialSend(sends).into())
+        }
+    }
+
+    /// sends the current batch of messages
+    pub async fn send_batch(&mut self) -> Result<(), Error> {
+        match &mut self.inner {
+            ProducerInner::Single(p) => p.send_batch().await,
+            ProducerInner::Partitioned(p) => {
+                try_join_all(p.producers.iter_mut().map(|p| p.send_batch()))
+                    .await
+                    .map(drop)
+            }
+        }
+    }
+
+    pub(crate) async fn send_raw(&mut self, message: ProducerMessage) -> Result<SendFuture, Error> {
+        match &mut self.inner {
+            ProducerInner::Single(p) => p.send_raw(message).await,
+            ProducerInner::Partitioned(p) => p.next().send_raw(message).await,
+        }
+    }
+}
+
+enum ProducerInner<Exe: Executor + ?Sized> {
+    Single(TopicProducer<Exe>),
+    Partitioned(PartitionedProducer<Exe>),
+}
+
+struct PartitionedProducer<Exe: Executor + ?Sized> {
+    // Guaranteed to be non-empty
+    producers: VecDeque<TopicProducer<Exe>>,
+    topic: String,
+    options: ProducerOptions,
+}
+
+impl<Exe: Executor + ?Sized> PartitionedProducer<Exe> {
+    pub fn next(&mut self) -> &mut TopicProducer<Exe> {
+        self.producers.rotate_left(1);
+        self.producers.front_mut().unwrap()
+    }
+}
+
+/// a producer is used to publish messages on a topic
+pub struct TopicProducer<Exe: Executor + ?Sized> {
     client: Pulsar<Exe>,
     connection: Arc<Connection>,
     id: ProducerId,
@@ -189,14 +328,14 @@ pub struct Producer<Exe: Executor + ?Sized> {
     options: ProducerOptions,
 }
 
-impl<Exe: Executor + ?Sized> Producer<Exe> {
-    pub async fn from_connection<S: Into<String>>(
+impl<Exe: Executor + ?Sized> TopicProducer<Exe> {
+    pub(crate) async fn from_connection<S: Into<String>>(
         client: Pulsar<Exe>,
         connection: Arc<Connection>,
         topic: S,
         name: Option<String>,
         options: ProducerOptions,
-    ) -> Result<Producer<Exe>, Error> {
+    ) -> Result<Self, Error> {
         let topic = topic.into();
         let producer_id = rand::random();
         let sequence_ids = SerialId::new();
@@ -227,8 +366,7 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
             Some(CompressionType::Snappy) => {
                 #[cfg(not(feature = "snap"))]
                 return Err(Error::Custom("cannot create a producer with Snappy compression because the 'snap' cargo feature is not active".to_string()));
-            }
-            //Some() => unimplemented!(),
+            } //Some() => unimplemented!(),
         };
 
         let success = connection
@@ -245,7 +383,7 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
             let _ = conn.sender().close_producer(producer_id).await;
         }));
 
-        Ok(Producer {
+        Ok(TopicProducer {
             client,
             connection,
             id: producer_id,
@@ -259,10 +397,6 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
         })
     }
 
-    pub fn is_valid(&self) -> bool {
-        self.connection.is_valid()
-    }
-
     pub fn topic(&self) -> &str {
         &self.topic
     }
@@ -271,122 +405,71 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
         &self.options
     }
 
-    pub fn create_message(&mut self) -> MessageBuilder<Unset, Exe> {
-        MessageBuilder::new(self)
-    }
-
     pub async fn check_connection(&self) -> Result<(), Error> {
         self.connection.sender().send_ping().await?;
         Ok(())
     }
 
-    /// sends a message
-    ///
-    /// this function returns a `Receiver` because the receipt can come long after
-    /// this function was called, for various reasons:
-    /// - the message was sent successfully but Pulsar did not send the receipt yet
-    /// - the producer is batching messages, so this function must return immediately,
-    /// and the receipt will come when the batched messages are actually sent
-    ///
-    /// Usage:
-    ///
-    /// ```rust,ignore
-    /// let f1 = producer.send("hello").await?;
-    /// let f2 = producer.send("world").await?;
-    /// let receipt1 = f.await;
-    /// let receipt2 = f.await;
-    /// ```
     pub async fn send<T: SerializeMessage + Sized>(
         &mut self,
         message: T,
-    ) -> Result<oneshot::Receiver<proto::CommandSendReceipt>, Error> {
+    ) -> Result<SendFuture, Error> {
         match T::serialize_message(message) {
             Ok(message) => self.send_raw(message.into()).await,
             Err(e) => Err(e),
         }
     }
 
-    pub async fn send_all<'a, 'b, T, I>(
-        &mut self,
-        messages: I,
-    ) -> Result<Vec<oneshot::Receiver<proto::CommandSendReceipt>>, Error>
-    where
-        'b: 'a,
-        T: 'b + SerializeMessage + Sized,
-        I: IntoIterator<Item = T>,
-    {
-        // TODO determine whether to keep this approach or go with the partial send, but more mem friendly lazy approach.
-        // serialize all messages before sending to avoid a partial send
-        match messages
-            .into_iter()
-            .map(|m| T::serialize_message(m))
-            .collect::<Result<Vec<_>, _>>()
-        {
-            Ok(messages) => {
-                let mut v = vec![];
-                for m in messages.into_iter() {
-                    v.push(self.send_raw(m.into()).await?);
-                }
-
-                Ok(v)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub fn error(&self) -> Option<Error> {
-        self.connection
-            .error()
-            .map(|e| ProducerError::Connection(e).into())
-    }
-
-    /// sends the current batch of messages
-    pub async fn send_batch(&mut self) -> Result<proto::CommandSendReceipt, Error> {
+    pub async fn send_batch(&mut self) -> Result<(), Error> {
         match self.batch.as_ref() {
             None => Err(ProducerError::Custom("not a batching producer".to_string()).into()),
             Some(batch) => {
                 let mut payload: Vec<u8> = Vec::new();
                 let mut receipts = Vec::new();
-                let mut counter = 0i32;
+                let message_count;
 
                 {
                     let batch = batch.lock().unwrap();
+                    message_count = batch.length;
 
                     for (tx, message) in batch.get_messages() {
                         receipts.push(tx);
                         message.serialize(&mut payload);
-                        counter += 1;
                     }
                 }
 
-                if counter > 0 {
-                    let message = ProducerMessage {
-                        payload,
-                        num_messages_in_batch: Some(counter),
-                        ..Default::default()
-                    };
-
-                    let send_receipt = self.send_compress(message).await?;
-
-                    trace!("sending a batched message of size {}", counter);
-                    Ok(send_receipt)
-                } else {
-                    Err(ProducerError::Custom("no messages to send".into()).into())
+                if message_count == 0 {
+                    return Ok(());
                 }
+
+                let message = ProducerMessage {
+                    payload,
+                    num_messages_in_batch: Some(message_count as i32),
+                    ..Default::default()
+                };
+
+                trace!("sending a batched message of size {}", message_count);
+                let send_receipt = self.send_compress(message).await.map_err(|e| Arc::new(e));
+                for resolver in receipts {
+                    let _ = resolver.send(
+                        send_receipt
+                            .clone()
+                            .map_err(|e| ProducerError::Batch(e).into()),
+                    );
+                }
+
+                Ok(())
             }
         }
     }
 
-    pub(crate) async fn send_raw(
-        &mut self,
-        message: ProducerMessage,
-    ) -> Result<oneshot::Receiver<proto::CommandSendReceipt>, Error> {
+    pub(crate) async fn send_raw(&mut self, message: ProducerMessage) -> Result<SendFuture, Error> {
         let (tx, rx) = oneshot::channel();
         match self.batch.as_ref() {
             None => {
                 let receipt = self.send_compress(message).await?;
-                let _ = tx.send(receipt);
-                Ok(rx)
+                let _ = tx.send(Ok(receipt));
+                Ok(SendFuture(rx))
             }
             Some(batch) => {
                 let mut payload: Vec<u8> = Vec::new();
@@ -413,15 +496,19 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
                         ..Default::default()
                     };
 
-                    let send_receipt = self.send_compress(message).await?;
+                    let send_receipt = self.send_compress(message).await.map_err(|e| Arc::new(e));
 
                     trace!("sending a batched message of size {}", counter);
                     for tx in receipts.drain(..) {
-                        let _ = tx.send(send_receipt.clone());
+                        let _ = tx.send(
+                            send_receipt
+                                .clone()
+                                .map_err(|e| ProducerError::Batch(e).into()),
+                        );
                     }
                 }
 
-                Ok(rx)
+                Ok(SendFuture(rx))
             }
         }
     }
@@ -593,70 +680,86 @@ impl<Exe: Executor + ?Sized> Producer<Exe> {
 /// Helper structure to prepare a producer
 ///
 /// generated from [Pulsar::producer]
-pub struct ProducerBuilder<'a, Topic, Exe: Executor + ?Sized> {
-    pulsar: &'a Pulsar<Exe>,
-    topic: Topic,
+pub struct ProducerBuilder<Exe: Executor + ?Sized> {
+    pulsar: Pulsar<Exe>,
+    topic: Option<String>,
     name: Option<String>,
     producer_options: Option<ProducerOptions>,
 }
 
-impl<'a, Exe: Executor + ?Sized> ProducerBuilder<'a, Set<String>, Exe> {
+impl<'a, Exe: Executor + ?Sized> ProducerBuilder<Exe> {
     pub async fn build(self) -> Result<Producer<Exe>, Error> {
         let ProducerBuilder {
             pulsar,
-            topic: Set(topic),
+            topic,
             name,
             producer_options,
         } = self;
+        let topic = topic.ok_or(Error::Custom(format!("topic not set")))?;
+        let options = producer_options.unwrap_or_default();
 
-        pulsar
-            .create_producer(topic, name, producer_options.unwrap_or_default())
-            .await
+        let producers: Vec<TopicProducer<Exe>> = try_join_all(
+            pulsar
+                .lookup_partitioned_topic(&topic)
+                .await?
+                .into_iter()
+                .map(|(topic, addr)| {
+                    let name = name.clone();
+                    let options = options.clone();
+                    let pulsar = pulsar.clone();
+                    async move {
+                        let conn = pulsar.manager.get_connection(&addr).await?;
+                        let producer =
+                            TopicProducer::from_connection(pulsar, conn, topic, name, options)
+                                .await?;
+                        Ok::<_, Error>(producer)
+                    }
+                }),
+        )
+        .await?;
+
+        let producer = if producers.len() == 1 {
+            ProducerInner::Single(producers.into_iter().next().unwrap())
+        } else if producers.len() > 1 {
+            let mut producers = VecDeque::from(producers);
+            // write to topic-1 first
+            producers.rotate_right(1);
+            ProducerInner::Partitioned(PartitionedProducer {
+                producers,
+                topic,
+                options,
+            })
+        } else {
+            return Err(Error::Custom(format!(
+                "Unexpected error: Partition lookup returned no topics for {}",
+                topic
+            )));
+        };
+        Ok(Producer { inner: producer })
     }
-}
 
-use crate::consumer::{Set, Unset};
-impl<'a, Exe: Executor + ?Sized> ProducerBuilder<'a, Unset, Exe> {
-    pub fn new(pulsar: &'a Pulsar<Exe>) -> Self {
+    pub fn new(pulsar: &Pulsar<Exe>) -> Self {
         ProducerBuilder {
-            pulsar,
-            topic: Unset,
+            pulsar: pulsar.clone(),
+            topic: None,
             name: None,
             producer_options: None,
         }
     }
-}
 
-impl<'a, Exe: Executor + ?Sized> ProducerBuilder<'a, Unset, Exe> {
-    pub fn with_topic<S: Into<String>>(self, topic: S) -> ProducerBuilder<'a, Set<String>, Exe> {
-        ProducerBuilder {
-            pulsar: self.pulsar,
-            topic: Set(topic.into()),
-            name: self.name,
-            producer_options: self.producer_options,
-        }
+    pub fn with_topic<S: Into<String>>(mut self, topic: S) -> Self {
+        self.topic = Some(topic.into());
+        self
     }
-}
 
-impl<'a, Topic, Exe: Executor + ?Sized> ProducerBuilder<'a, Topic, Exe> {
-    pub fn with_name<S: Into<String>>(self, name: S) -> ProducerBuilder<'a, Topic, Exe> {
-        ProducerBuilder {
-            pulsar: self.pulsar,
-            topic: self.topic,
-            name: Some(name.into()),
-            producer_options: self.producer_options,
-        }
+    pub fn with_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
     }
-}
 
-impl<'a, Topic, Exe: Executor + ?Sized> ProducerBuilder<'a, Topic, Exe> {
-    pub fn with_options(self, options: ProducerOptions) -> ProducerBuilder<'a, Topic, Exe> {
-        ProducerBuilder {
-            pulsar: self.pulsar,
-            topic: self.topic,
-            name: self.name,
-            producer_options: Some(options),
-        }
+    pub fn with_options(mut self, options: ProducerOptions) -> Self {
+        self.producer_options = Some(options);
+        self
     }
 }
 
@@ -664,7 +767,12 @@ struct Batch {
     pub length: u32,
     // put it in a mutex because the design of Producer requires an immutable TopicProducer,
     // so we cannot have a mutable Batch in a send_raw(&mut self, ...)
-    pub storage: Mutex<VecDeque<(oneshot::Sender<proto::CommandSendReceipt>, BatchedMessage)>>,
+    pub storage: Mutex<
+        VecDeque<(
+            oneshot::Sender<Result<proto::CommandSendReceipt, Error>>,
+            BatchedMessage,
+        )>,
+    >,
 }
 
 impl Batch {
@@ -679,7 +787,13 @@ impl Batch {
         self.storage.lock().unwrap().len() >= self.length as usize
     }
 
-    pub fn push_back(&self, msg: (oneshot::Sender<proto::CommandSendReceipt>, ProducerMessage)) {
+    pub fn push_back(
+        &self,
+        msg: (
+            oneshot::Sender<Result<proto::CommandSendReceipt, Error>>,
+            ProducerMessage,
+        ),
+    ) {
         let (tx, message) = msg;
 
         let properties = message
@@ -702,7 +816,10 @@ impl Batch {
 
     pub fn get_messages(
         &self,
-    ) -> Vec<(oneshot::Sender<proto::CommandSendReceipt>, BatchedMessage)> {
+    ) -> Vec<(
+        oneshot::Sender<Result<proto::CommandSendReceipt, Error>>,
+        BatchedMessage,
+    )> {
         self.storage.lock().unwrap().drain(..).collect()
     }
 }
@@ -710,67 +827,52 @@ impl Batch {
 /// Helper structure to prepare a message
 ///
 /// generated with [Producer::create_message]
-pub struct MessageBuilder<'a, Content, Exe: Executor + ?Sized> {
+pub struct MessageBuilder<'a, T, Exe: Executor + ?Sized> {
     producer: &'a mut Producer<Exe>,
     properties: HashMap<String, String>,
     partition_key: Option<String>,
-    content: Content,
+    content: T,
 }
 
-impl<'a, Exe: Executor + ?Sized> MessageBuilder<'a, Unset, Exe> {
+impl<'a, Exe: Executor + ?Sized> MessageBuilder<'a, (), Exe> {
     pub fn new(producer: &'a mut Producer<Exe>) -> Self {
         MessageBuilder {
             producer,
             properties: HashMap::new(),
             partition_key: None,
-            content: Unset,
+            content: (),
         }
     }
 }
 
-impl<'a, Exe: Executor + ?Sized> MessageBuilder<'a, Unset, Exe> {
-    pub fn with_content<T>(self, content: T) -> MessageBuilder<'a, Set<T>, Exe> {
+impl<'a, T, Exe: Executor + ?Sized> MessageBuilder<'a, T, Exe> {
+    pub fn with_content<C>(self, content: C) -> MessageBuilder<'a, C, Exe> {
         MessageBuilder {
             producer: self.producer,
             properties: self.properties,
             partition_key: self.partition_key,
-            content: Set(content),
+            content,
         }
     }
-}
 
-impl<'a, Content, Exe: Executor + ?Sized> MessageBuilder<'a, Content, Exe> {
-    pub fn with_partition_key<S: Into<String>>(
-        self,
-        partition_key: S,
-    ) -> MessageBuilder<'a, Content, Exe> {
-        MessageBuilder {
-            producer: self.producer,
-            properties: self.properties,
-            partition_key: Some(partition_key.into()),
-            content: self.content,
-        }
+    pub fn with_partition_key<S: Into<String>>(mut self, partition_key: S) -> Self {
+        self.partition_key = Some(partition_key.into());
+        self
     }
-}
 
-impl<'a, Content, Exe: Executor + ?Sized> MessageBuilder<'a, Content, Exe> {
-    pub fn with_property<S1: Into<String>, S2: Into<String>>(
-        mut self,
-        key: S1,
-        value: S2,
-    ) -> MessageBuilder<'a, Content, Exe> {
+    pub fn with_property<S1: Into<String>, S2: Into<String>>(mut self, key: S1, value: S2) -> Self {
         self.properties.insert(key.into(), value.into());
         self
     }
 }
 
-impl<'a, T: SerializeMessage + Sized, Exe: Executor + ?Sized> MessageBuilder<'a, Set<T>, Exe> {
-    pub async fn send(self) -> Result<oneshot::Receiver<proto::CommandSendReceipt>, Error> {
+impl<'a, T: SerializeMessage + Sized, Exe: Executor + ?Sized> MessageBuilder<'a, T, Exe> {
+    pub async fn send(self) -> Result<SendFuture, Error> {
         let MessageBuilder {
             producer,
             properties,
             partition_key,
-            content: Set(content),
+            content,
         } = self;
 
         let mut message = T::serialize_message(content)?;

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -176,15 +176,17 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
         }
     }
 
-    /// get the list of topic names and addresses for a partitioned topic
+    /// Lookup a topic, returning a list of the partitions (if partitioned) and addresses
+    /// associated with that topic.
     pub async fn lookup_partitioned_topic<S: Into<String>>(
         &self,
         topic: S,
     ) -> Result<Vec<(String, BrokerAddress)>, ServiceDiscoveryError> {
         let topic = topic.into();
         let partitions = self.lookup_partitioned_topic_number(&topic).await?;
+        trace!("Partitions for topic {}: {}", &topic, &partitions);
         let topics = match partitions {
-            1 => vec![topic],
+            0 => vec![topic],
             _ => (0..partitions).map(|n| format!("{}-partition-{}", &topic, n)).collect(),
         };
         try_join_all(topics.into_iter().map(|topic| {


### PR DESCRIPTION
Major changes: 
1. Everything is only constructible from a builder. This allows us to add improvements without breaking the API
2. The phantom types on the builders have been removed
3. Both consumers and producers handle partitions transparently
4. The same public consumer type is used for regex-matched consumers vs explicit topic consumers
5. The client's `send` is backed by the MultiTopicProducer
6. Tests cleaned up and simplified
7. All doc-tests compile
8. (most) implementation details are no longer public (`messages` still are).