### PR TITLE
executor: Store an instance instead of using raw methods

### DIFF
--- a/examples/batching.rs
+++ b/examples/batching.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), pulsar::Error> {
     env_logger::init();
 
     let addr = "pulsar://127.0.0.1:6650";
-    let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+    let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
     let mut producer = pulsar
         .producer()
         .with_topic("test-batch-compression-snappy")

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), pulsar::Error> {
     env_logger::init();
 
     let addr = "pulsar://127.0.0.1:6650";
-    let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+    let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
 
     let mut consumer: Consumer<TestData, _> = pulsar
         .consumer()

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), pulsar::Error> {
     env_logger::init();
 
     let addr = "pulsar://127.0.0.1:6650";
-    let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+    let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
     let mut producer = pulsar
         .producer()
         .with_topic("non-persistent://public/default/test")

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), pulsar::Error> {
     env_logger::init();
 
     let addr = "pulsar://127.0.0.1:6650";
-    let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+    let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
     let mut producer = pulsar
         .producer()
         .with_topic("test")
@@ -67,7 +67,7 @@ async fn main() -> Result<(), pulsar::Error> {
         }
     });
 
-    let pulsar2: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+    let pulsar2: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
 
     let mut consumer: Consumer<TestData, _> = pulsar2
         .consumer()

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -2,7 +2,6 @@ use crate::connection::{Authentication, Connection};
 use crate::error::ConnectionError;
 use crate::executor::Executor;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -58,10 +57,10 @@ enum ConnectionStatus {
 /// interacting with a cluster. It will automatically follow redirects
 /// or use a proxy, and aggregate broker connections
 #[derive(Clone)]
-pub struct ConnectionManager<Exe: Executor + ?Sized> {
+pub struct ConnectionManager<Exe: Executor> {
     pub url: Url,
     auth: Option<Authentication>,
-    executor: PhantomData<Exe>,
+    pub(crate) executor: Arc<Exe>,
     connections: Arc<Mutex<HashMap<BrokerAddress, ConnectionStatus>>>,
     back_off_options: BackOffOptions,
     tls_options: TlsOptions,
@@ -74,6 +73,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         auth: Option<Authentication>,
         backoff: Option<BackOffOptions>,
         tls: Option<TlsOptions>,
+        executor: Arc<Exe>,
     ) -> Result<Self, ConnectionError> {
         let back_off_options = backoff.unwrap_or_default();
         let tls_options = tls.unwrap_or_default();
@@ -99,7 +99,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         let manager = ConnectionManager {
             url: url.clone(),
             auth,
-            executor: PhantomData,
+            executor,
             connections: Arc::new(Mutex::new(HashMap::new())),
             back_off_options,
             tls_options,
@@ -218,11 +218,12 @@ impl<Exe: Executor> ConnectionManager<Exe> {
 
         let start = std::time::Instant::now();
         let conn = loop {
-            match Connection::new::<Exe>(
+            match Connection::new(
                 broker.url.clone(),
                 self.auth.clone(),
                 proxy_url.clone(),
                 &self.certificate_chain,
+                self.executor.clone(),
             )
             .await
             {
@@ -254,7 +255,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                         broker.url,
                         current_backoff.as_millis()
                     );
-                    Exe::delay(current_backoff).await;
+                    self.executor.delay(current_backoff).await;
                 }
                 Err(e) => return Err(e),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!     env_logger::init();
 //!
 //!     let addr = "pulsar://127.0.0.1:6650";
-//!     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+//!     let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
 //!     let mut producer = pulsar
 //!         .producer()
 //!         .with_topic("non-persistent://public/default/test")
@@ -101,7 +101,7 @@
 //!     env_logger::init();
 //!
 //!     let addr = "pulsar://127.0.0.1:6650";
-//!     let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await?;
+//!     let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
 //!
 //!     let mut consumer: Consumer<TestData, _> = pulsar
 //!         .consumer()
@@ -294,7 +294,7 @@ mod tests {
         let _ = log::set_max_level(LevelFilter::Debug);
 
         let addr = "pulsar://127.0.0.1:6650";
-        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+        let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
 
         // random topic to better allow multiple test runs while debugging
         let topic = format!("test_{}", rand::random::<u16>());
@@ -359,7 +359,7 @@ mod tests {
 
         let addr = "pulsar://127.0.0.1:6650";
         let test_id: u16 = rand::random();
-        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+        let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
 
         // test &str
         {
@@ -446,7 +446,7 @@ mod tests {
         let addr = "pulsar://127.0.0.1:6650";
         let topic = format!("test_redelivery_{}", rand::random::<u16>());
 
-        let pulsar: Pulsar<TokioExecutor> = Pulsar::builder(addr).build().await.unwrap();
+        let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
         pulsar
             .send(&topic, String::from("data"))
             .await

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -15,7 +15,7 @@ use url::Url;
 /// interacting with a cluster. It will automatically follow redirects
 /// or use a proxy, and aggregate broker connections
 #[derive(Clone)]
-pub struct ServiceDiscovery<Exe: Executor + ?Sized> {
+pub struct ServiceDiscovery<Exe: Executor> {
     manager: Arc<ConnectionManager<Exe>>,
 }
 
@@ -64,7 +64,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
                 {
                     error!("lookup({}) answered ServiceNotReady, retrying request after 500ms (max_retries = {})", topic, max_retries);
                     max_retries -= 1;
-                    Exe::delay(Duration::from_millis(500)).await;
+                    self.manager.executor.delay(Duration::from_millis(500)).await;
                     continue;
                 }
                 return Err(ServiceDiscoveryError::Query(
@@ -155,7 +155,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
                 {
                     error!("lookup_partitioned_topic_number({}) answered ServiceNotReady, retrying request after 500ms (max_retries = {})", topic, max_retries);
                     max_retries -= 1;
-                    Exe::delay(Duration::from_millis(500)).await;
+                    self.manager.executor.delay(Duration::from_millis(500)).await;
                     continue;
                 }
                 return Err(ServiceDiscoveryError::Query(


### PR DESCRIPTION
This allows some consumer of pulsar-rs to define a custom executor that can carry some state around

It also makes things easier when some software (vector being an exemple) already carries an object around to abstract the executor on top of some other one. This way we can just pass that object around.