### PR TITLE
2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.0", features = ["full"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
-asynchronous-codec = { version = "0.5", optional = true }
+asynchronous-codec = { version = "0.6", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ travis-ci = {repository = "wyyerd/pulsar-rs"}
 bytes = "1.0.0"
 crc = "1.0.0"
 futures = "0.3"
-nom = "6.0.0"
+nom = { version="6.0.0", default-features=false, features=["alloc"] }
 prost = "0.7.0"
 prost-derive = "0.7.0"
 rand = "0.8"
-chrono = "0.4.6"
+chrono = "0.4"
 futures-timer = "3.0"
 log = "0.4.6"
 url = "2.1"
@@ -35,7 +35,7 @@ bit-vec = "0.6"
 futures-io = "0.3"
 native-tls = "0.2"
 pem = "0.8"
-tokio = { version = "1.0", features = ["full"], optional = true }
+tokio = { version = "1.0", features = ["rt", "net", "time"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
@@ -50,6 +50,7 @@ snap = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 env_logger = "0.8"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 prost-build = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pem = "0.8"
 tokio = { version = "1.0", features = ["rt", "net", "time"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
-async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
+async-std = {version = "1.9", features = [ "attributes", "unstable" ], optional = true }
 asynchronous-codec = { version = "0.6", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["pulsar", "api", "client"]
 travis-ci = {repository = "wyyerd/pulsar-rs"}
 
 [dependencies]
-bytes = "0.5.0"
+bytes = "1.0.0"
 crc = "1.0.0"
 futures = "0.3"
 nom = "6.0.0"
@@ -35,11 +35,11 @@ bit-vec = "0.6"
 futures-io = "0.3"
 native-tls = "0.2"
 pem = "0.8"
-tokio = { version = "0.2", features = ["rt-threaded", "blocking", "full"], optional = true }
-tokio-util = { version = "0.3", features = ["codec"], optional = true }
-tokio-native-tls = { version = "0.1", optional = true }
-async-std = {version = "1.9", features = [ "attributes", "unstable" ], optional = true }
-futures_codec = { version = "0.4", optional = true }
+tokio = { version = "1.0", features = ["full"], optional = true }
+tokio-util = { version = "0.6", features = ["codec"], optional = true }
+tokio-native-tls = { version = "0.3", optional = true }
+async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
+futures_codec = { version = "0.4", optional = true, git = "git://github.com/Keruspe/futures-codec", branch = "bytes1" }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.0", features = ["full"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
-futures_codec = { version = "0.4", optional = true, git = "git://github.com/Keruspe/futures-codec", branch = "bytes1" }
+asynchronous-codec = { version = "0.5", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
@@ -58,4 +58,4 @@ prost-build = "0.7.0"
 default = [ "compression", "tokio-runtime", "async-std-runtime" ]
 compression = [ "lz4", "flate2", "zstd", "snap" ]
 tokio-runtime = [ "tokio", "tokio-util", "tokio-native-tls" ]
-async-std-runtime = [ "async-std", "futures_codec", "async-native-tls" ]
+async-std-runtime = [ "async-std", "asynchronous-codec", "async-native-tls" ]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ async fn main() -> Result<(), pulsar::Error> {
 
         counter += 1;
         println!("{} messages", counter);
-        tokio::time::delay_for(std::time::Duration::from_millis(2000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
     }
 }
 ```

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -70,6 +70,6 @@ async fn main() -> Result<(), pulsar::Error> {
 
         counter += 1;
         println!("{} messages", counter);
-        tokio::time::delay_for(std::time::Duration::from_millis(2000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -487,26 +487,23 @@ impl Connection {
         };
 
         let u = url.clone();
-        let address: SocketAddr = match executor
-            .spawn_blocking(move || {
-                u.socket_addrs(|| match u.scheme() {
-                    "pulsar" => Some(6650),
-                    "pulsar+ssl" => Some(6651),
-                    _ => None,
-                })
-                .map_err(|e| {
-                    error!("could not look up address: {:?}", e);
-                    e
-                })
-                .ok()
-                .and_then(|v| {
-                    let mut rng = thread_rng();
-                    let index: usize = rng.gen_range(0..v.len());
-                    v.get(index).copied()
-                })
+        let address: SocketAddr = match executor.spawn_blocking(move || {
+            u.socket_addrs(|| match u.scheme() {
+                "pulsar" => Some(6650),
+                "pulsar+ssl" => Some(6651),
+                _ => None,
             })
-            .await
-        {
+            .map_err(|e| {
+                error!("could not look up address: {:?}", e);
+                e
+            })
+            .ok()
+            .and_then(|v| {
+                let mut rng = thread_rng();
+                let index: usize = rng.gen_range(0..v.len());
+                v.get(index).copied()
+            })
+        }).await {
             Some(Some(address)) => address,
             _ =>
             //return Err(Error::Custom(format!("could not query address: {}", url))),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,6 +9,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
+use std::time::Duration;
 
 use futures::{
     self,
@@ -471,6 +472,7 @@ impl Connection {
         auth_data: Option<Authentication>,
         proxy_to_broker_url: Option<String>,
         certificate_chain: &[Certificate],
+        connection_timeout: Duration,
         executor: Arc<Exe>,
     ) -> Result<Connection, ConnectionError> {
         if url.scheme() != "pulsar" && url.scheme() != "pulsar+ssl" {
@@ -526,7 +528,7 @@ impl Connection {
             certificate_chain,
             executor.clone(),
         );
-        let delay_f = executor.delay(std::time::Duration::from_secs(10));
+        let delay_f = executor.delay(connection_timeout);
 
         pin_mut!(sender_prepare);
         pin_mut!(delay_f);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -580,13 +580,13 @@ impl Connection {
                     let stream = connector
                         .connect(&hostname, stream)
                         .await
-                        .map(|stream| futures_codec::Framed::new(stream, Codec))?;
+                        .map(|stream| asynchronous_codec::Framed::new(stream, Codec))?;
 
                     Connection::connect(stream, auth_data, proxy_to_broker_url, executor).await
                 } else {
                     let stream = async_std::net::TcpStream::connect(&address)
                         .await
-                        .map(|stream| futures_codec::Framed::new(stream, Codec))?;
+                        .map(|stream| asynchronous_codec::Framed::new(stream, Codec))?;
 
                     Connection::connect(stream, auth_data, proxy_to_broker_url, executor).await
                 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -28,6 +28,7 @@ pub struct BackOffOptions {
     pub min_backoff: Duration,
     pub max_backoff: Duration,
     pub max_retries: u32,
+    pub connection_timeout: Duration,
 }
 
 impl std::default::Default for BackOffOptions {
@@ -36,6 +37,7 @@ impl std::default::Default for BackOffOptions {
             min_backoff: Duration::from_millis(10),
             max_backoff: Duration::from_secs(30),
             max_retries: 12u32,
+            connection_timeout: Duration::from_secs(10),
         }
     }
 }
@@ -231,6 +233,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 self.auth.clone(),
                 proxy_url.clone(),
                 &self.certificate_chain,
+                self.back_off_options.connection_timeout,
                 self.executor.clone(),
             )
             .await

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1912,7 +1912,7 @@ mod tests {
             println!("created second consumer");
 
             // the message has already been acked, so we should not receive anything
-            let res: Result<_, tokio::time::Elapsed> =
+            let res: Result<_, tokio::time::error::Elapsed> =
                 tokio::time::timeout(Duration::from_secs(1), consumer.next()).await;
             let is_err = res.is_err();
             if let Ok(val) = res {

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1851,7 +1851,7 @@ mod tests {
 
         let message = TestData {
             topic: std::iter::repeat(())
-                .map(|()| rand::thread_rng().sample(Alphanumeric))
+                .map(|()| rand::thread_rng().sample(Alphanumeric) as char)
                 .take(8)
                 .map(|c| c as char)
                 .collect(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!
 //!         counter += 1;
 //!         println!("{} messages", counter);
-//!         tokio::time::delay_for(std::time::Duration::from_millis(2000)).await;
+//!         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
 //!     }
 //! }
 //! ```

--- a/src/message.rs
+++ b/src/message.rs
@@ -301,7 +301,7 @@ impl tokio_util::codec::Decoder for Codec {
 }
 
 #[cfg(feature = "async-std-runtime")]
-impl futures_codec::Encoder for Codec {
+impl asynchronous_codec::Encoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 
@@ -350,7 +350,7 @@ impl futures_codec::Encoder for Codec {
 }
 
 #[cfg(feature = "async-std-runtime")]
-impl futures_codec::Decoder for Codec {
+impl asynchronous_codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 


### PR DESCRIPTION
this is mainly a release to support tokio 1.0. Otherwise, the only difference with the current 1.1.0 version is the connection timeout code, that adds a new member in `BackOffOptions`