### PR TITLE
Implement a Reader

### DIFF
--- a/examples/reader.rs
+++ b/examples/reader.rs
@@ -1,0 +1,87 @@
+#[macro_use]
+extern crate serde;
+use futures::TryStreamExt;
+use pulsar::{
+    consumer::ConsumerOptions, proto::Schema, reader::Reader, Authentication, DeserializeMessage,
+    Payload, Pulsar, TokioExecutor,
+};
+use std::env;
+
+#[derive(Serialize, Deserialize)]
+struct TestData {
+    data: String,
+}
+
+impl DeserializeMessage for TestData {
+    type Output = Result<TestData, serde_json::Error>;
+
+    fn deserialize_message(payload: &Payload) -> Self::Output {
+        serde_json::from_slice(&payload.data)
+    }
+}
+#[tokio::main]
+async fn main() -> Result<(), pulsar::Error> {
+    env_logger::init();
+
+    let addr = env::var("PULSAR_ADDRESS")
+        .ok()
+        .unwrap_or_else(|| "pulsar://127.0.0.1:6650".to_string());
+    let topic = env::var("PULSAR_TOPIC")
+        .ok()
+        .unwrap_or_else(|| "non-persistent://public/default/test".to_string());
+
+    let mut builder = Pulsar::builder(addr, TokioExecutor);
+
+    if let Ok(token) = env::var("PULSAR_TOKEN") {
+        let authentication = Authentication {
+            name: "token".to_string(),
+            data: token.into_bytes(),
+        };
+
+        builder = builder.with_auth(authentication);
+    }
+
+    let pulsar: Pulsar<_> = builder.build().await?;
+
+    let mut reader: Reader<TestData, _> = pulsar
+        .reader()
+        .with_topic(topic)
+        .with_consumer_name("test_reader")
+        .with_options(ConsumerOptions::default().with_schema(Schema {
+            r#type: pulsar::proto::schema::Type::String as i32,
+            ..Default::default()
+        }))
+        // subscription defaults to SubType::Exclusive
+        .into_reader()
+        .await?;
+    // log::info!("created a reader");
+
+    let mut counter = 0usize;
+
+    // listen to 5 messages
+    while let Some(msg) = reader.try_next().await? {
+        log::info!("metadata: {:#?}", msg.metadata());
+
+        log::info!("id: {:?}", msg.message_id());
+        let data = match msg.deserialize() {
+            Ok(data) => data,
+            Err(e) => {
+                log::error!("Could not deserialize message: {:?}", e);
+                break;
+            }
+        };
+
+        if data.data.as_str() != "data" {
+            log::error!("Unexpected payload: {}", &data.data);
+            break;
+        }
+        counter += 1;
+
+        if counter > 5 {
+            break;
+        }
+        log::info!("got {} messages", counter);
+    }
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use crate::connection::Authentication;
 use crate::connection_manager::{
     BrokerAddress, ConnectionManager, ConnectionRetryOptions, OperationRetryOptions, TlsOptions,
 };
-use crate::consumer::ConsumerBuilder;
+use crate::consumer::{ConsumerBuilder, ConsumerOptions, InitialPosition};
 use crate::error::Error;
 use crate::executor::Executor;
 use crate::message::proto::{self, CommandSendReceipt};
@@ -277,6 +277,30 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// ```
     pub fn producer(&self) -> ProducerBuilder<Exe> {
         ProducerBuilder::new(self)
+    }
+
+    /// creates a reader builder
+    /// ```rust, no_run
+    /// use pulsar::reader::Reader;
+    ///
+    /// # async fn run(pulsar: pulsar::Pulsar<pulsar::TokioExecutor>) -> Result<(), pulsar::Error> {
+    /// # type TestData = String;
+    /// let mut reader: Reader<TestData, _> = pulsar
+    ///     .reader()
+    ///     .with_topic("non-persistent://public/default/test")
+    ///     .with_consumer_name("my_reader")
+    ///     .into_reader()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn reader(&self) -> ConsumerBuilder<Exe> {
+        // this makes it exactly the same like the consumer() method though
+        ConsumerBuilder::new(self).with_options(
+            ConsumerOptions::default()
+                .durable(false)
+                .with_initial_position(InitialPosition::Latest),
+        )
     }
 
     /// gets the address of a broker handling the topic

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,6 +132,7 @@ pub enum ConsumerError {
     Io(io::Error),
     ChannelFull,
     Closed,
+    BuildError,
 }
 
 impl From<ConnectionError> for ConsumerError {
@@ -170,6 +171,10 @@ impl fmt::Display for ConsumerError {
                 f,
                 "cannot send message to the consumer engine: the channel is closed"
             ),
+            ConsumerError::BuildError => write!(
+                f,
+                "Error while building the consumer."
+            )
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub mod error;
 pub mod executor;
 pub mod message;
 pub mod producer;
+pub mod reader;
 mod service_discovery;
 
 #[cfg(test)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,160 @@
+use crate::client::DeserializeMessage;
+use crate::consumer::{ConsumerOptions, DeadLetterPolicy, EngineMessage, Message, TopicConsumer};
+use crate::error::Error;
+use crate::executor::Executor;
+use crate::message::proto::{command_subscribe::SubType, MessageIdData};
+use chrono::{DateTime, Utc};
+use futures::channel::mpsc::SendError;
+use futures::task::{Context, Poll};
+use futures::{Future, SinkExt, Stream};
+use std::pin::Pin;
+use url::Url;
+
+/// A client that acknowledges messages systematically
+pub struct Reader<T: DeserializeMessage, Exe: Executor> {
+    pub(crate) consumer: TopicConsumer<T, Exe>,
+    pub(crate) state: Option<State<T>>,
+}
+
+impl<T: DeserializeMessage + 'static, Exe: Executor> Unpin for Reader<T, Exe> {}
+
+pub enum State<T: DeserializeMessage> {
+    PollingConsumer,
+    PollingAck(
+        Message<T>,
+        Pin<Box<dyn Future<Output = Result<(), SendError>>>>,
+    ),
+}
+
+impl<T: DeserializeMessage + 'static, Exe: Executor> Stream for Reader<T, Exe> {
+    type Item = Result<Message<T>, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.state.take().unwrap() {
+            State::PollingConsumer => match Pin::new(&mut this.consumer).poll_next(cx) {
+                Poll::Pending => {
+                    this.state = Some(State::PollingConsumer);
+                    Poll::Pending
+                }
+
+                Poll::Ready(None) => {
+                    this.state = Some(State::PollingConsumer);
+                    Poll::Ready(None)
+                }
+
+                Poll::Ready(Some(Ok(msg))) => {
+                    let mut acker = this.consumer.acker();
+                    let message_id = msg.message_id.clone();
+                    this.state = Some(State::PollingAck(
+                        msg,
+                        Box::pin(
+                            async move { acker.send(EngineMessage::Ack(message_id, false)).await },
+                        ),
+                    ));
+                    return Pin::new(this).poll_next(cx);
+                }
+
+                Poll::Ready(Some(Err(e))) => {
+                    this.state = Some(State::PollingConsumer);
+                    Poll::Ready(Some(Err(e)))
+                }
+            },
+            State::PollingAck(msg, mut ack_fut) => match ack_fut.as_mut().poll(cx) {
+                Poll::Pending => {
+                    this.state = Some(State::PollingAck(msg, ack_fut));
+                    return Poll::Pending;
+                }
+
+                Poll::Ready(res) => {
+                    this.state = Some(State::PollingConsumer);
+                    return Poll::Ready(Some(
+                        res.map_err(|err| Error::Consumer(err.into())).map(|()| msg),
+                    ));
+                }
+            },
+        }
+    }
+}
+
+impl<T: DeserializeMessage, Exe: Executor> Reader<T, Exe> {
+    // this is totally useless as calling ConsumerBuilder::new(&pulsar_client)
+    // does just the same
+    /*
+    /// creates a [ReaderBuilder] from a client instance
+    pub fn builder(pulsar: &Pulsar<Exe>) -> ConsumerBuilder<Exe> {
+        ConsumerBuilder::new(pulsar)
+    }
+    */
+
+    /// test that the connections to the Pulsar brokers are still valid
+    pub async fn check_connection(&mut self) -> Result<(), Error> {
+        self.consumer.check_connection().await
+    }
+
+    /// returns topic this reader is subscribed on
+    pub fn topic(&self) -> String {
+        self.consumer.topic()
+    }
+
+    /// returns a list of broker URLs this reader is connnected to
+    pub async fn connections(&mut self) -> Result<Url, Error> {
+        Ok(self.consumer.connection().await?.url().clone())
+    }
+    /// returns the consumer's configuration options
+    pub fn options(&self) -> &ConsumerOptions {
+        &self.consumer.config.options
+    }
+
+    // is this necessary?
+    /// returns the consumer's dead letter policy options
+    pub fn dead_letter_policy(&self) -> Option<&DeadLetterPolicy> {
+        self.consumer.dead_letter_policy.as_ref()
+    }
+
+    /// returns the readers's subscription name
+    pub fn subscription(&self) -> &str {
+        &self.consumer.config.subscription
+    }
+    /// returns the reader's subscription type
+    pub fn sub_type(&self) -> SubType {
+        self.consumer.config.sub_type
+    }
+
+    /// returns the reader's batch size
+    pub fn batch_size(&self) -> Option<u32> {
+        self.consumer.config.batch_size
+    }
+
+    /// returns the reader's name
+    pub fn reader_name(&self) -> Option<&str> {
+        self.consumer
+            .config
+            .consumer_name
+            .as_ref()
+            .map(|s| s.as_str())
+    }
+
+    /// returns the reader's id
+    pub fn reader_id(&self) -> u64 {
+        self.consumer.consumer_id
+    }
+
+    pub async fn seek(
+        &mut self,
+        message_id: Option<MessageIdData>,
+        timestamp: Option<u64>,
+    ) -> Result<(), Error> {
+        self.consumer.seek(message_id, timestamp).await
+    }
+
+    /// returns the date of the last message reception
+    pub fn last_message_received(&self) -> Option<DateTime<Utc>> {
+        self.consumer.last_message_received()
+    }
+
+    /// returns the current number of messages received
+    pub fn messages_received(&self) -> u64 {
+        self.consumer.messages_received()
+    }
+}


### PR DESCRIPTION
The Apache Software Foundation considers integrating pulsar-rs, see issue #126 

In order to expand the rust client's features, we need to implement a Reader interface, as suggested at issue #144 . A Reader is a pulsar client that immediately aknowledges messages upon reception.