### PR TITLE
Support insecure TLS connections

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -425,9 +425,24 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
 
     /// add a custom certificate chain to authenticate the server in TLS connections
     pub fn with_certificate_chain(mut self, certificate_chain: Vec<u8>) -> Self {
-        self.tls_options = Some(TlsOptions {
-            certificate_chain: Some(certificate_chain),
-        });
+        match &mut self.tls_options {
+            Some(tls) => tls.certificate_chain = Some(certificate_chain),
+            None => self.tls_options = Some(TlsOptions {
+                certificate_chain: Some(certificate_chain),
+                ..Default::default()
+            })
+        }
+        self
+    }
+
+    pub fn with_allow_insecure_connection(mut self, allow: bool) -> Self {
+        match &mut self.tls_options {
+            Some(tls) => tls.allow_insecure_connection = allow,
+            None => self.tls_options = Some(TlsOptions {
+                allow_insecure_connection: allow,
+                ..Default::default()
+            })
+        }
         self
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -446,6 +446,17 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
         self
     }
 
+    pub fn with_tls_hostname_verification_enabled(mut self, enabled: bool) -> Self {
+        match &mut self.tls_options {
+            Some(tls) => tls.tls_hostname_verification_enabled = enabled,
+            None => self.tls_options = Some(TlsOptions {
+                tls_hostname_verification_enabled: enabled,
+                ..Default::default()
+            })
+        }
+        self
+    }
+
     /// add a custom certificate chain from a file to authenticate the server in TLS connections
     pub fn with_certificate_chain_file<P: AsRef<std::path::Path>>(
         self,

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -75,6 +75,9 @@ impl std::default::Default for OperationRetryOptions {
 pub struct TlsOptions {
     /// contains a list of PEM encoded certificates
     pub certificate_chain: Option<Vec<u8>>,
+
+    /// Allow insecure TLS connection if set to true
+    pub allow_insecure_connection: bool
 }
 
 enum ConnectionStatus<Exe: Executor> {
@@ -269,6 +272,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 self.auth.clone(),
                 proxy_url.clone(),
                 &self.certificate_chain,
+                self.tls_options.allow_insecure_connection,
                 self.connection_retry_options.connection_timeout,
                 self.operation_retry_options.operation_timeout,
                 self.executor.clone(),

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -76,8 +76,11 @@ pub struct TlsOptions {
     /// contains a list of PEM encoded certificates
     pub certificate_chain: Option<Vec<u8>>,
 
-    /// Allow insecure TLS connection if set to true
-    pub allow_insecure_connection: bool
+    /// allow insecure TLS connection if set to true
+    pub allow_insecure_connection: bool,
+
+    /// whether hostname verification is enabled when insecure TLS connection is allowed
+    pub tls_hostname_verification_enabled: bool,
 }
 
 enum ConnectionStatus<Exe: Executor> {
@@ -273,6 +276,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 proxy_url.clone(),
                 &self.certificate_chain,
                 self.tls_options.allow_insecure_connection,
+                self.tls_options.tls_hostname_verification_enabled,
                 self.connection_retry_options.connection_timeout,
                 self.operation_retry_options.operation_timeout,
                 self.executor.clone(),


### PR DESCRIPTION
Add an option to allow insecure TLS connections which is useful in test environments.