### PR TITLE
Upgrade to prost 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ bytes = "1.0.0"
 crc = "2.0.0"
 futures = "0.3"
 nom = { version="6.0.0", default-features=false, features=["alloc"] }
-prost = "0.7.0"
-prost-derive = "0.7.0"
+prost = "0.8.0"
+prost-derive = "0.8.0"
 rand = "0.8"
 chrono = "0.4"
 futures-timer = "3.0"
@@ -53,7 +53,7 @@ env_logger = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-prost-build = "0.7.0"
+prost-build = "0.8.0"
 
 [features]
 default = [ "compression", "tokio-runtime", "async-std-runtime" ]


### PR DESCRIPTION
0.7 has a newly reported security vulnerability:

https://rustsec.org/advisories/RUSTSEC-2021-0073.html

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>