### PR TITLE
fix: Lock nom version to 7.0.0-alpha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = {repository = "wyyerd/pulsar-rs"}
 bytes = "1.0.0"
 crc = "2.0.0"
 futures = "0.3"
-nom = { version="7.0.0-alpha1", default-features=false, features=["alloc"] }
+nom = { version="=7.0.0-alpha1", default-features=false, features=["alloc"] }
 prost = "0.8.0"
 prost-derive = "0.8.0"
 rand = "0.8"


### PR DESCRIPTION
7.0.0-alpha2 removes the `named!` macro.

Addresses https://github.com/wyyerd/pulsar-rs/issues/167