### PR TITLE
Use u32 for metadata.payload_size

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -497,7 +497,7 @@ fn batched_message(i: &[u8]) -> IResult<&[u8], BatchedMessage> {
         |metadata| metadata.payload_size >= 0,
     )(i)?;
 
-    let (i, payload) = take(metadata.payload_size as u64)(i)?;
+    let (i, payload) = take(metadata.payload_size as u32)(i)?;
 
     Ok((
         i,


### PR DESCRIPTION
As, on 32-bit architectures, u64 doesn't satisfy `ToUsize` that `nom` expects.

Closes #169 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>