### PR TITLE
Support oauth2 authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
 zstd = { version = "0.9", optional = true }
 snap = { version = "1.0", optional = true }
+openidconnect = { version = "2.1.1", optional = true }
+oauth2 = { version = "4.1", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+async-trait = "0.1.51"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -56,7 +61,8 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 prost-build = "0.9.0"
 
 [features]
-default = [ "compression", "tokio-runtime", "async-std-runtime" ]
+default = [ "compression", "tokio-runtime", "async-std-runtime", "auth-oauth2" ]
 compression = [ "lz4", "flate2", "zstd", "snap" ]
 tokio-runtime = [ "tokio", "tokio-util", "tokio-native-tls" ]
 async-std-runtime = [ "async-std", "asynchronous-codec", "async-native-tls" ]
+auth-oauth2 = [ "openidconnect", "oauth2", "serde", "serde_json" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ oauth2 = { version = "4.1", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 async-trait = "0.1.51"
+data-url = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -65,4 +66,4 @@ default = [ "compression", "tokio-runtime", "async-std-runtime", "auth-oauth2" ]
 compression = [ "lz4", "flate2", "zstd", "snap" ]
 tokio-runtime = [ "tokio", "tokio-util", "tokio-native-tls" ]
 async-std-runtime = [ "async-std", "asynchronous-codec", "async-native-tls" ]
-auth-oauth2 = [ "openidconnect", "oauth2", "serde", "serde_json" ]
+auth-oauth2 = [ "openidconnect", "oauth2", "serde", "serde_json", "data-url" ]

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -5,6 +5,7 @@ use pulsar::{
     Authentication, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
 };
 use std::env;
+use pulsar::authentication::oauth2::{OAuth2Authentication};
 
 #[derive(Serialize, Deserialize)]
 struct TestData {
@@ -39,6 +40,10 @@ async fn main() -> Result<(), pulsar::Error> {
         };
 
         builder = builder.with_auth(authentication);
+    } else if let Ok(oauth2_cfg) = env::var("PULSAR_OAUTH2") {
+        builder = builder.with_auth_provider(OAuth2Authentication::client_credentials(
+            serde_json::from_str(oauth2_cfg.as_str())
+                .expect(format!("invalid oauth2 config [{}]", oauth2_cfg.as_str()).as_str())));
     }
 
     let pulsar: Pulsar<_> = builder.build().await?;

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -5,6 +5,7 @@ use pulsar::{
     TokioExecutor,
 };
 use std::env;
+use pulsar::authentication::oauth2::{OAuth2Authentication};
 
 #[derive(Serialize, Deserialize)]
 struct TestData {
@@ -41,6 +42,10 @@ async fn main() -> Result<(), pulsar::Error> {
         };
 
         builder = builder.with_auth(authentication);
+    } else if let Ok(oauth2_cfg) = env::var("PULSAR_OAUTH2") {
+        builder = builder.with_auth_provider(OAuth2Authentication::client_credentials(
+            serde_json::from_str(oauth2_cfg.as_str())
+                .expect(format!("invalid oauth2 config [{}]", oauth2_cfg.as_str()).as_str())));
     }
 
     let pulsar: Pulsar<_> = builder.build().await?;

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,190 @@
+use async_trait::async_trait;
+
+use crate::Error;
+
+#[async_trait]
+pub trait Authentication {
+    fn auth_method_name(&self) -> String;
+
+    async fn initialize(&mut self) -> Result<(), Error>;
+
+    async fn auth_data(&mut self) -> Result<Vec<u8>, Error>;
+}
+
+pub mod token {
+    use std::rc::Rc;
+
+    use async_trait::async_trait;
+
+    use crate::authentication::Authentication;
+    use crate::Error;
+
+    pub struct TokenAuthentication {
+        token: Vec<u8>,
+    }
+
+    impl TokenAuthentication {
+        pub fn new(token: String) -> Rc<dyn Authentication> {
+            Rc::new(TokenAuthentication {
+                token: token.into_bytes()
+            })
+        }
+    }
+
+    #[async_trait]
+    impl Authentication for TokenAuthentication {
+        fn auth_method_name(&self) -> String {
+            String::from("token")
+        }
+
+        async fn initialize(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn auth_data(&mut self) -> Result<Vec<u8>, Error> {
+            Ok(self.token.clone())
+        }
+    }
+}
+
+#[cfg(feature = "auth-oauth2")]
+pub mod oauth2 {
+    use std::fs;
+
+    use async_trait::async_trait;
+    use oauth2::{AuthUrl, ClientId, ClientSecret, Scope, TokenResponse, TokenUrl};
+    use oauth2::AuthType::RequestBody;
+    use oauth2::basic::{BasicClient, BasicTokenResponse};
+    use oauth2::reqwest::async_http_client;
+    use openidconnect::core::CoreProviderMetadata;
+    use openidconnect::IssuerUrl;
+    use serde::Deserialize;
+    use url::Url;
+
+    use crate::authentication::Authentication;
+    use crate::Error;
+    use crate::error::AuthenticationError;
+
+    #[derive(Deserialize, Debug)]
+    struct OAuth2PrivateParams {
+        client_id: String,
+        client_secret: String,
+        client_email: Option<String>,
+        issuer_url: Option<String>,
+    }
+
+    #[derive(Deserialize, Debug)]
+    pub struct OAuth2Params {
+        issuer_url: Url,
+        credentials_url: Url,
+        audience: String,
+        scope: Option<String>,
+    }
+
+    pub struct OAuth2Authentication {
+        params: OAuth2Params,
+        private_params: Option<OAuth2PrivateParams>,
+        token_url: Option<TokenUrl>,
+        token: Option<BasicTokenResponse>,
+    }
+
+    impl OAuth2Authentication {
+        pub fn client_credentials(params: OAuth2Params) -> Box<dyn Authentication> {
+            Box::new(OAuth2Authentication {
+                params,
+                private_params: None,
+                token_url: None,
+                token: None,
+            })
+        }
+    }
+
+    impl OAuth2Params {
+        fn read_private_params(&self) -> Result<OAuth2PrivateParams, Error> {
+            if self.credentials_url.scheme() != "file" {
+                return Err(Error::Authentication(AuthenticationError::Custom(format!("invalid credential url [{}]", self.credentials_url.as_str()))));
+            }
+            let path = self.credentials_url.path();
+            Ok(serde_json::from_str(fs::read_to_string(path).unwrap().as_str()).unwrap())
+        }
+    }
+
+    #[async_trait]
+    impl Authentication for OAuth2Authentication {
+        fn auth_method_name(&self) -> String {
+            String::from("token")
+        }
+
+        async fn initialize(&mut self) -> Result<(), Error> {
+            self.private_params = Some(self.params.read_private_params()?);
+            if let Err(e) = self.token_url().await {
+                return Err(Error::Authentication(AuthenticationError::Custom(e.to_string())));
+            }
+            Ok(())
+        }
+
+        async fn auth_data(&mut self) -> Result<Vec<u8>, Error> {
+            if self.private_params.is_none() {
+                return Err(Error::Authentication(AuthenticationError::Custom("not initialized".to_string())));
+            }
+            match self.token.as_ref() {
+                Some(token) => Ok(token.access_token().secret().clone().into_bytes()),
+                None => {
+                    match self.fetch_token().await {
+                        Ok(token) => {
+                            self.token = Some(token);
+                            Ok(self.token.as_ref().unwrap().access_token().secret().clone().into_bytes())
+                        }
+                        Err(e) => {
+                            Err(Error::Authentication(AuthenticationError::Custom(e.to_string())))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    impl OAuth2Authentication {
+        async fn token_url(&mut self) -> Result<Option<TokenUrl>, Box<dyn std::error::Error>> {
+            match &self.token_url {
+                Some(url) => Ok(Some(url.clone())),
+                None => {
+                    let metadata = CoreProviderMetadata::discover_async(
+                        IssuerUrl::from_url(self.params.issuer_url.clone()), async_http_client).await?;
+                    self.token_url = Some(metadata.token_endpoint().unwrap().clone());
+                    match metadata.token_endpoint() {
+                        Some(endpoint) => {
+                            Ok(Some(endpoint.clone()))
+                        }
+                        None => Err(Box::new(Error::Authentication(AuthenticationError::Custom("token endpoint is unavailable".to_string()))))
+                    }
+                }
+            }
+        }
+
+        async fn fetch_token(&mut self) -> Result<BasicTokenResponse, Box<dyn std::error::Error>> {
+            let private_params = self.private_params.as_ref()
+                .expect("oauth2 provider is uninitialized");
+
+            let client = BasicClient::new(
+                ClientId::new(private_params.client_id.clone()),
+                Some(ClientSecret::new(private_params.client_secret.clone())),
+                AuthUrl::from_url(self.params.issuer_url.clone()),
+                self.token_url().await?)
+                .set_auth_type(RequestBody);
+
+            let mut request = client
+                .exchange_client_credentials()
+                .add_extra_param("audience", self.params.audience.clone());
+
+            if let Some(scope) = &self.params.scope {
+                request = request.add_scope(Scope::new(scope.clone()));
+            }
+
+            let token = request
+                .request_async(async_http_client).await?;
+            info!("Got a new token: {:?}\n{}", token, token.access_token().secret());
+            Ok(token)
+        }
+    }
+}

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -188,6 +188,8 @@ pub mod oauth2 {
                     }
                     Err(e) => {
                         if none_or_expired {
+                            // invalidate the expired token
+                            self.token = None;
                             return Err(AuthenticationError::Custom(e.to_string()));
                         } else {
                             warn!("failed to get a new token for [{}], use the existing one for now", self.params);

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::Error;
 
 #[async_trait]
-pub trait Authentication {
+pub trait Authentication: Send + Sync + 'static {
     fn auth_method_name(&self) -> String;
 
     async fn initialize(&mut self) -> Result<(), Error>;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -29,6 +29,8 @@ use crate::message::{
     BaseCommand, Codec, Message,
 };
 use crate::producer::{self, ProducerOptions};
+use crate::Error;
+use async_trait::async_trait;
 
 pub(crate) enum Register {
     Request {
@@ -60,6 +62,21 @@ pub struct Authentication {
     pub name: String,
     /// Authentication data
     pub data: Vec<u8>,
+}
+
+#[async_trait]
+impl crate::authentication::Authentication for Authentication {
+    fn auth_method_name(&self) -> String {
+        self.name.clone()
+    }
+
+    async fn initialize(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn auth_data(&mut self) -> Result<Vec<u8>, Error> {
+        Ok(self.data.clone())
+    }
 }
 
 pub(crate) struct Receiver<S: Stream<Item = Result<Message, ConnectionError>>> {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -158,7 +158,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         };
 
         if let Some(auth) = auth.clone() {
-            auth.lock().await.initialize().await.unwrap();
+            auth.lock().await.initialize().await?;
         }
 
         let manager = ConnectionManager {

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,6 +79,7 @@ pub enum ConnectionError {
     SocketAddr(String),
     UnexpectedResponse(String),
     Tls(native_tls::Error),
+    Authentication(AuthenticationError),
     NotFound,
     Canceled,
     Shutdown,
@@ -96,6 +97,12 @@ impl From<native_tls::Error> for ConnectionError {
     }
 }
 
+impl From<AuthenticationError> for ConnectionError {
+    fn from(err: AuthenticationError) -> Self {
+        ConnectionError::Authentication(err)
+    }
+}
+
 impl fmt::Display for ConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -109,6 +116,7 @@ impl fmt::Display for ConnectionError {
             ConnectionError::Encoding(e) => write!(f, "Error encoding message: {}", e),
             ConnectionError::SocketAddr(e) => write!(f, "Error obtaining socket address: {}", e),
             ConnectionError::Tls(e) => write!(f, "Error connecting TLS stream: {}", e),
+            ConnectionError::Authentication(e) => write!(f, "Error authentication: {}", e),
             ConnectionError::UnexpectedResponse(e) => {
                 write!(f, "Unexpected response from pulsar: {}", e)
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     Consumer(ConsumerError),
     Producer(ProducerError),
     ServiceDiscovery(ServiceDiscoveryError),
+    Authentication(AuthenticationError),
     Custom(String),
     Executor,
 }
@@ -46,6 +47,7 @@ impl fmt::Display for Error {
             Error::Consumer(e) => write!(f, "consumer error: {}", e),
             Error::Producer(e) => write!(f, "producer error: {}", e),
             Error::ServiceDiscovery(e) => write!(f, "service discovery error: {}", e),
+            Error::Authentication(e) => write!(f, "authentication error: {}", e),
             Error::Custom(e) => write!(f, "error: {}", e),
             Error::Executor => write!(f, "could not spawn task"),
         }
@@ -59,6 +61,7 @@ impl std::error::Error for Error {
             Error::Consumer(e) => e.source(),
             Error::Producer(e) => e.source(),
             Error::ServiceDiscovery(e) => e.source(),
+            Error::Authentication(e) => e.source(),
             Error::Custom(_) => None,
             Error::Executor => None,
         }
@@ -319,6 +322,23 @@ impl std::error::Error for ServiceDiscoveryError {
             _ => None,
         }
     }
+}
+
+#[derive(Debug)]
+pub enum AuthenticationError {
+    Custom(String)
+}
+
+impl fmt::Display for AuthenticationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthenticationError::Custom(m) => write!(f, "authentication error [{}]", m)
+        }
+    }
+}
+
+impl std::error::Error for AuthenticationError {
+
 }
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod executor;
 pub mod message;
 pub mod producer;
 pub mod reader;
+pub mod authentication;
 mod service_discovery;
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds support of authentication methods that generate authentication data dynamically.

- Add a trait `authentication::Authentication` to abstract authentication providers
- Implement `authentication::Authentication` for `connection::Authentication` to make it as a special `authentication::Authentication` implementation.
- Refactor code to use `authentication::Authentication`
  - Initialize the authentication provider at the time of creating the `ConnectionManager`
  - Get the authentication data asynchronously after connected to the remote server
- Implement a token provider
- Implement an (optional) oauth2 provider
  - Basically follows the example of the oauth2 implementation in the pulsar client: https://github.com/apache/pulsar/tree/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2
  - Cache the access token in memory and request new tokens automatically.
- Add oauth2 support in examples of producer and consumer.