### PR TITLE
make Reader Sync + Send

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -22,7 +22,7 @@ pub enum State<T: DeserializeMessage> {
     PollingConsumer,
     PollingAck(
         Message<T>,
-        Pin<Box<dyn Future<Output = Result<(), SendError>>>>,
+        Pin<Box<dyn Future<Output = Result<(), SendError>> + Send + Sync>>,
     ),
 }
 


### PR DESCRIPTION
Hi

We are using `Reader` interface recently and we want to generate tokio thread for consumption via `tokio::spawn`, but this requires Reader to be `Sync + Send`, so this is a patch for issue #184 

