### PR TITLE
Add get_consumer_stats function

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -341,6 +341,18 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    pub async fn get_consumer_stats(
+        &self,
+        consumer_id: u64,
+    ) -> Result<proto::CommandConsumerStatsResponse, ConnectionError> {
+        let request_id = self.request_id.get();
+        let msg = messages::consumer_stats(request_id, consumer_id);
+        self.send_message(msg, RequestKey::RequestId(request_id), |resp| {
+            resp.command.consumer_stats_response
+        })
+        .await
+    }
+
     pub async fn create_producer(
         &self,
         topic: String,
@@ -1065,6 +1077,21 @@ pub(crate) mod messages {
                 partition_metadata: Some(proto::CommandPartitionedTopicMetadata {
                     topic,
                     request_id,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            payload: None,
+        }
+    }
+
+    pub fn consumer_stats(request_id: u64, consumer_id: u64) -> Message {
+        Message {
+            command: proto::BaseCommand {
+                r#type: CommandType::ConsumerStats as i32,
+                consumer_stats: Some(proto::CommandConsumerStats {
+                    request_id,
+                    consumer_id,
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -414,6 +414,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                             "could not ping connection {} to the server at {}: {}",
                             connection_id, broker_url, e
                         );
+                        break;
                     }
                 } else {
                     // if the strong pointers were dropped, we can stop the heartbeat for this

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -879,6 +879,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                     match message_opt {
                         None => {
                             error!("Consumer: messages::next: returning Disconnected");
+                            panic!("ConsumerEngine got Disconnected");
                             self.reconnect().await?;
                             continue;
                             //return Err(Error::Consumer(ConsumerError::Connection(ConnectionError::Disconnected)).into());


### PR DESCRIPTION
Add get consumer stats functionality to check if any consumers go wrong, we can do something like reconnecting brokers, when wired things happen in the pulsar server side.