### PR TITLE
Bump zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ asynchronous-codec = { version = "0.6", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
-zstd = { version = "0.9", optional = true }
+zstd = { version = "0.10", optional = true }
 snap = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
From `0.9` to `0.10`. Because `0.10` is required by `actix-http v3.0.0` and `actix-web v4.0.0`.