### PR TITLE
Enable ordering_key for key_shared subscription

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -55,6 +55,8 @@ pub struct Message {
     pub properties: HashMap<String, String>,
     /// key to decide partition for the message
     pub partition_key: ::std::option::Option<String>,
+    /// key to decide partition for the message
+    pub ordering_key: ::std::option::Option<Vec<u8>>,
     /// Override namespace's replication
     pub replicate_to: ::std::vec::Vec<String>,
     /// the timestamp that this event occurs. it is typically set by applications.
@@ -72,6 +74,8 @@ pub(crate) struct ProducerMessage {
     pub properties: HashMap<String, String>,
     ///key to decide partition for the msg
     pub partition_key: ::std::option::Option<String>,
+    ///key to decide partition for the msg
+    pub ordering_key: ::std::option::Option<Vec<u8>>,
     /// Override namespace's replication
     pub replicate_to: ::std::vec::Vec<String>,
     pub compression: ::std::option::Option<i32>,
@@ -100,6 +104,7 @@ impl From<Message> for ProducerMessage {
             payload: m.payload,
             properties: m.properties,
             partition_key: m.partition_key,
+            ordering_key: m.ordering_key,
             replicate_to: m.replicate_to,
             event_time: m.event_time,
             schema_version: m.schema_version,
@@ -989,6 +994,7 @@ impl Batch {
             metadata: proto::SingleMessageMetadata {
                 properties,
                 partition_key: message.partition_key,
+                ordering_key: message.ordering_key,
                 payload_size: message.payload.len() as i32,
                 ..Default::default()
             },
@@ -1014,6 +1020,7 @@ pub struct MessageBuilder<'a, T, Exe: Executor> {
     producer: &'a mut Producer<Exe>,
     properties: HashMap<String, String>,
     partition_key: Option<String>,
+    ordering_key: Option<Vec<u8>>,
     deliver_at_time: Option<i64>,
     event_time: Option<u64>,
     content: T,
@@ -1026,6 +1033,7 @@ impl<'a, Exe: Executor> MessageBuilder<'a, (), Exe> {
             producer,
             properties: HashMap::new(),
             partition_key: None,
+            ordering_key: None,
             deliver_at_time: None,
             event_time: None,
             content: (),
@@ -1040,6 +1048,7 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
             producer: self.producer,
             properties: self.properties,
             partition_key: self.partition_key,
+            ordering_key: self.ordering_key,
             deliver_at_time: self.deliver_at_time,
             event_time: self.event_time,
             content,
@@ -1048,6 +1057,11 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
 
     /// sets the message's partition key
     pub fn with_partition_key<S: Into<String>>(mut self, partition_key: S) -> Self {
+        self.partition_key = Some(partition_key.into());
+        self
+    }
+    /// sets the message's ordering key for key_shared subscription
+    pub fn with_ordering_key<S: Into<String>>(mut self, partition_key: S) -> Self {
         self.partition_key = Some(partition_key.into());
         self
     }
@@ -1099,6 +1113,7 @@ impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> 
             producer,
             properties,
             partition_key,
+            ordering_key,
             content,
             deliver_at_time,
             event_time,
@@ -1107,6 +1122,7 @@ impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> 
         let mut message = T::serialize_message(content)?;
         message.properties = properties;
         message.partition_key = partition_key;
+        message.ordering_key = ordering_key;
         message.event_time = event_time;
 
         let mut producer_message: ProducerMessage = message.into();


### PR DESCRIPTION
ordering_key is already defined In the PulsarApi.proto, this is just add the corresponding key to message body.