### PR TITLE
Fix connection error handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 async-trait = "0.1.51"
 data-url = { version = "0.1.1", optional = true }
+uuid = {version = "1.1.2", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -569,7 +569,6 @@ async fn run_producer<Exe: Executor>(
 
                 let _ = client.executor.spawn(Box::pin(async move {
                     pin_mut!(delay_f);
-                    pin_mut!(send_f);
                     match select(send_f, delay_f).await {
                         Either::Left((res, _)) => {
                             let _ = resolver.send(res);

--- a/src/client.rs
+++ b/src/client.rs
@@ -437,7 +437,10 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
         self.with_auth_provider(Box::new(auth))
     }
 
-    pub fn with_auth_provider(mut self, auth: Box<dyn crate::authentication::Authentication>) -> Self {
+    pub fn with_auth_provider(
+        mut self,
+        auth: Box<dyn crate::authentication::Authentication>,
+    ) -> Self {
         self.auth_provider = Some(auth);
         self
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -373,7 +373,6 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         })
         .await
     }
-
     pub async fn get_last_message_id(
         &self,
         consumer_id: u64,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -583,13 +583,36 @@ impl<Exe: Executor> ConnectionSender<Exe> {
                         // println!("recv msg: {:?}", res);
                         res
                     }
-                    Either::Right(_) => Err(ConnectionError::Io(std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "timeout sending message to the Pulsar server",
-                    ))),
+                    Either::Right(_) => {
+                        warn!(
+                            "connection {} timedout sending message to the Pulsar server",
+                            self.connection_id
+                        );
+                        self.error.set(ConnectionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!(
+                                " connection {} timedout sending message to the Pulsar server",
+                                self.connection_id
+                            ),
+                        )));
+                        Err(ConnectionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!(
+                                " connection {} timedout sending message to the Pulsar server",
+                                self.connection_id
+                            ),
+                        )))
+                    }
                 }
             }
-            _ => Err(ConnectionError::Disconnected),
+            _ => {
+                warn!(
+                    "connection {} disconnected sending message to the Pulsar server",
+                    self.connection_id
+                );
+                self.error.set(ConnectionError::Disconnected);
+                Err(ConnectionError::Disconnected)
+            }
         }
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -744,6 +744,7 @@ impl<Exe: Executor> Connection<Exe> {
         match select(sender_prepare, delay_f).await {
             Either::Left((res, _)) => sender = res?,
             Either::Right(_) => {
+                warn!("TimedOut connecting to the pulsar server {}", line!());
                 return Err(ConnectionError::Io(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     "timeout connecting to the Pulsar server",

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1201,7 +1201,6 @@ pub(crate) mod messages {
             payload: None,
         }
     }
-
     pub fn get_last_message_id(consumer_id: u64, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -64,7 +64,7 @@ impl std::default::Default for OperationRetryOptions {
     fn default() -> Self {
         OperationRetryOptions {
             operation_timeout: Duration::from_secs(30),
-            retry_delay: Duration::from_millis(500),
+            retry_delay: Duration::from_secs(30),
             max_retries: None,
         }
     }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -338,7 +338,10 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                     );
                     self.executor.delay(current_backoff).await;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    error!("connection error, not retryable: {:?}", e);
+                    return Err(e);
+                }
             }
         };
         let connection_id = conn.id();

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,4 +1,4 @@
-use crate::connection::{Connection};
+use crate::connection::Connection;
 use crate::error::ConnectionError;
 use crate::executor::Executor;
 use std::collections::HashMap;
@@ -418,8 +418,10 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 }
                 if let Some(strong_conn) = weak_conn.upgrade() {
                     if !strong_conn.is_valid() {
-                        trace!("connection {} is not valid anymore, skip heart beat task",
-                             connection_id);
+                        trace!(
+                            "connection {} is not valid anymore, skip heart beat task",
+                            connection_id
+                        );
                         break;
                     }
                     if let Err(e) = strong_conn.sender().send_ping().await {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -482,6 +482,12 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                     // in a mutex, and a case appears where the Arc is cloned
                     // somewhere at the same time, that just means the manager
                     // will create a new connection the next time it is asked
+                    trace!(
+                        "checking connection {}, is valid? {}, strong_count {}",
+                        conn.id(),
+                        conn.is_valid(),
+                        Arc::strong_count(conn)
+                    );
                     conn.is_valid() && Arc::strong_count(conn) > 1
                 }
             });

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -64,7 +64,7 @@ impl std::default::Default for OperationRetryOptions {
     fn default() -> Self {
         OperationRetryOptions {
             operation_timeout: Duration::from_secs(30),
-            retry_delay: Duration::from_secs(30),
+            retry_delay: Duration::from_secs(5),
             max_retries: None,
         }
     }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1778,7 +1778,8 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     async fn get_last_message_id(&mut self) -> Result<Vec<MessageIdData>, Error> {
-        let responses = try_join_all(self.consumers.values_mut().map(|c| c.get_last_message_id())).await?;
+        let responses =
+            try_join_all(self.consumers.values_mut().map(|c| c.get_last_message_id())).await?;
         Ok(responses)
     }
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -774,6 +774,14 @@ impl<Exe: Executor> TopicProducer<Exe> {
 
         self.connection = conn;
 
+        warn!(
+            "Retry #0 -> reconnecting producer {:#} using connection {:#} to broker {:#} to topic {:#}",
+            self.id,
+            self.connection.id(),
+            broker_address.url,
+            self.topic
+        );
+
         let topic = self.topic.clone();
         let batch_size = self.options.batch_size;
 
@@ -827,6 +835,15 @@ impl<Exe: Executor> TopicProducer<Exe> {
 
                         let addr = self.client.lookup_topic(&topic).await?;
                         self.connection = self.client.manager.get_connection(&addr).await?;
+
+                        warn!(
+                            "Retry #{} -> reconnecting producer {:#} using connection {:#} to broker {:#} to topic {:#}",
+                            current_retries,
+                            self.id,
+                            self.connection.id(),
+                            broker_address.url,
+                            self.topic
+                        );
 
                         continue;
                     } else {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -858,7 +858,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                 )
                 .await
                 .map_err(|e| {
-                    error!("TopicProducer::from_connection error[{}]: {:?}", line!(), e);
+                    error!("TopicProducer::create_producer error[{}]: {:?}", line!(), e);
                     e
                 }) {
                 Ok(_success) => {
@@ -986,7 +986,10 @@ impl<Exe: Executor> TopicProducer<Exe> {
                         }
                     }
                 }
-                Err(e) => return Err(Error::Connection(e)),
+                Err(e) => {
+                    error!("reconnect error[{:?}]: {:?}", line!(), e);
+                    return Err(Error::Connection(e));
+                }
             }
         }
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -822,8 +822,8 @@ impl<Exe: Executor> TopicProducer<Exe> {
         // as the sender is hold by the TopicProducer, there is no way to call send method
         // The lines below take the pointed sender and replace it by a new one bound to nothing
         // but as the TopicProducer sender is recreate below, there is no worry
-        let (_drop_signal, _) = oneshot::channel::<()>();
-        let old_signal = std::mem::replace(&mut self.drop_signal, _drop_signal);
+        let (drop_signal, _) = oneshot::channel::<()>();
+        let old_signal = std::mem::replace(&mut self.drop_signal, drop_signal);
         // This line ask for kill the previous errored producer
         let _ = old_signal.send(());
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -849,7 +849,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     if operation_retry_options.max_retries.is_none()
                         || operation_retry_options.max_retries.unwrap() > current_retries
                     {
-                        error!("create_producer({}) answered ServiceNotReady, retrying request after {}ms (max_retries = {:?}): {}",
+                        warn!("create_producer({}) answered ServiceNotReady, retrying request after {}ms (max_retries = {:?}): {}",
                         topic, operation_retry_options.retry_delay.as_millis(),
                         operation_retry_options.max_retries, text.unwrap_or_else(String::new));
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -458,7 +458,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     if current_retries > 0 {
                         let dur = (std::time::Instant::now() - start).as_secs();
                         log::info!(
-                            "subscribe({}) success after {} retries over {} seconds",
+                            "producer({}) success after {} retries over {} seconds",
                             topic,
                             current_retries + 1,
                             dur
@@ -808,7 +808,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     if current_retries > 0 {
                         let dur = (std::time::Instant::now() - start).as_secs();
                         log::info!(
-                            "subscribe({}) success after {} retries over {} seconds",
+                            "producer({}) success after {} retries over {} seconds",
                             topic,
                             current_retries + 1,
                             dur


### PR DESCRIPTION
Closes https://github.com/streamnative/pulsar-rs/issues/214. But based on https://github.com/streamnative/pulsar-rs/pull/216.

Not fixed, but better information:

Using a broker that never responds to `handleSend` messages in order to trigger timeout on the client's side. And running the `round_trip`:

I get

```
2022-06-20 14:04:09.167886395 UTC  DEBUG        pulsar::connection_manager      ConnectionManager::connect(BrokerAddress { url: Url { scheme: "pulsar", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("127.0.0.1")), port: Some(6650), path: "", query: None, fragment: None }, broker_url: "127.0.0
.1:6650", proxy: false })                                                      
2022-06-20 14:04:09.168203314 UTC  DEBUG        pulsar::connection      Connecting to pulsar://127.0.0.1:6650: 127.0.0.1:6650                                                                                                                                                                                                  
2022-06-20 14:04:09.169212514 UTC  INFO pulsar::connection_manager      Connected n°-1498647850098426708 to pulsar://127.0.0.1:6650 in 1ms                                                                                                                                                                                     
2022-06-20 14:04:09.174852628 UTC  DEBUG        pulsar::connection_manager      ConnectionManager::connect(BrokerAddress { url: Url { scheme: "pulsar", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("127.0.0.1")), port: Some(6650), path: "", query: None, fragment: None }, broker_url: "localho
st:6650", proxy: true })                                                                                                                                       
2022-06-20 14:04:09.174979977 UTC  DEBUG        pulsar::connection      Connecting to pulsar://127.0.0.1:6650: 127.0.0.1:6650                                                                                                                                                                                                  
2022-06-20 14:04:09.175861348 UTC  INFO pulsar::connection_manager      Connected n°671655203122723910 to localhost:6650 via proxy pulsar://127.0.0.1:6650 in 0ms                                                                                                                                                              
2022-06-20 14:04:09.228102904 UTC  INFO pulsar::tests   producer created                                                                                       
2022-06-20 14:04:09.228370575 UTC  INFO pulsar::tests   will send message                                                                                      
2022-06-20 14:04:14.229866885 UTC  WARN pulsar::connection      timeout sending message to the Pulsar server                                                                                                                                                                                                                   
2022-06-20 14:04:14.229960438 UTC  WARN pulsar::producer        set connection failing with Timeout                                                            
2022-06-20 14:04:14.230019880 UTC  ERROR        pulsar::producer        send_inner: connection 671655203122723910 disconnected                                                                                                                                                                                                 
2022-06-20 14:04:14.232225958 UTC  DEBUG        pulsar::connection_manager      ConnectionManager::connect(BrokerAddress { url: Url { scheme: "pulsar", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("127.0.0.1")), port: Some(6650), path: "", query: None, fragment: None }, broker_url: "localho
st:6650", proxy: true })                                                       
2022-06-20 14:04:14.232710937 UTC  DEBUG        pulsar::connection      Connecting to pulsar://127.0.0.1:6650: 127.0.0.1:6650                                                                                                                                                                                                  
2022-06-20 14:04:14.235752054 UTC  INFO pulsar::connection_manager      Connected n°-2079755032641021880 to localhost:6650 via proxy pulsar://127.0.0.1:6650 in 3ms                                                                                                                                                            
2022-06-20 14:04:14.235948481 UTC  WARN pulsar::producer        Retry #0 -> reconnecting producer 11864658257378581019 using connection -2079755032641021880 to broker pulsar://127.0.0.1:6650 to topic test_31704                                                                                                             
2022-06-20 14:04:14.238421810 UTC  ERROR        pulsar::producer        TopicProducer::from_connection error[824]: PulsarError(Some(ProducerBusy), Some("org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic"))                        
2022-06-20 14:04:14.238538923 UTC  WARN pulsar::producer        create_producer(test_31704) answered ProducerBusy, retrying request after 15000ms (max_retries = None): org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic
2022-06-20 14:04:29.240694096 UTC  DEBUG        pulsar::connection_manager      ConnectionManager::connect(BrokerAddress { url: Url { scheme: "pulsar", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("127.0.0.1")), port: Some(6650), path: "", query: None, fragment: None }, broker_url: "127.0.0
.1:6650", proxy: false })                                                                                                                                      
2022-06-20 14:04:29.241627023 UTC  DEBUG        pulsar::connection      Connecting to pulsar://127.0.0.1:6650: 127.0.0.1:6650                                                                                                                                                                                                  
2022-06-20 14:04:29.245784677 UTC  INFO pulsar::connection_manager      Connected n°2819212208112083275 to pulsar://127.0.0.1:6650 in 4ms                                                                                                                                                                                      
2022-06-20 14:04:29.248246600 UTC  WARN pulsar::producer        Retry #1 -> reconnecting producer 11864658257378581019 using connection -2079755032641021880 to broker pulsar://127.0.0.1:6650 to topic test_31704                                                                                                             
2022-06-20 14:04:29.250873017 UTC  ERROR        pulsar::producer        TopicProducer::from_connection error[824]: PulsarError(Some(ProducerBusy), Some("org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic"))                        
2022-06-20 14:04:29.250955631 UTC  WARN pulsar::producer        create_producer(test_31704) answered ProducerBusy, retrying request after 15000ms (max_retries = None): org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic
2022-06-20 14:04:44.254643743 UTC  WARN pulsar::producer        Retry #2 -> reconnecting producer 11864658257378581019 using connection -2079755032641021880 to broker pulsar://127.0.0.1:6650 to topic test_31704                                                                                                             
2022-06-20 14:04:44.277827897 UTC  ERROR        pulsar::producer        TopicProducer::from_connection error[824]: PulsarError(Some(ProducerBusy), Some("org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic"))                        
2022-06-20 14:04:44.277904791 UTC  WARN pulsar::producer        create_producer(test_31704) answered ProducerBusy, retrying request after 15000ms (max_retries = None): org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'standalone-0-39' is already connected to topic
2022-06-20 14:04:59.278871712 UTC  DEBUG        pulsar::connection_manager      ConnectionManager::connect(BrokerAddress { url: Url { scheme: "pulsar", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("127.0.0.1")), port: Some(6650), path: "", query: None, fragment: None }, broker_url: "127.0.0
.1:6650", proxy: false })
```

To it seems the producer is held on an unreleased connection. Using `lsof -i :6650` we can see one port not cleaned; I don't understand why.

You can easily reproduce by running `test_round` test using

```bash
cargo test round_trip -- --nocapture
```

On a pulsar standalone patched with

```git
From 57348b0e8d81ee9554744202214c3c713f9881f2 Mon Sep 17 00:00:00 2001
From: "Alexandre DUVAL - @kannarfr" <kannarfr@gmail.com>
Date: Mon, 20 Jun 2022 16:13:42 +0200
Subject: [PATCH] make handleSend timeout

---
 .../java/org/apache/pulsar/common/protocol/PulsarDecoder.java | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
index ecf837b536..7d13623617 100644
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -203,8 +203,8 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 try {
                     interceptCommand(cmd);
                     // Store a buffer marking the content + headers
-                    ByteBuf headersAndPayload = buffer.markReaderIndex();
-                    handleSend(cmd.getSend(), headersAndPayload);
+                    //ByteBuf headersAndPayload = buffer.markReaderIndex();
+                    //handleSend(cmd.getSend(), headersAndPayload);
                 } catch (InterceptException e) {
                     ctx.writeAndFlush(Commands.newSendError(cmd.getSend().getProducerId(),
                             cmd.getSend().getSequenceId(), getServerError(e.getErrorCode()), e.getMessage()));
-- 
2.36.1
```