### PR TITLE
Update zstd version to support Solana crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ asynchronous-codec = { version = "0.6", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
-zstd = { version = "0.10", optional = true }
+zstd = { version = "0.11", optional = true }
 snap = { version = "1.0", optional = true }
 openidconnect = { version = "2.1.1", optional = true }
 oauth2 = { version = "4.1", optional = true }


### PR DESCRIPTION
## What
Update zstd version 0.10 -> 0.11
## Why
To support Solana crates
