### PR TITLE
fix: Add uncompressed_size to message

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -672,6 +672,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                         .map_err(ProducerError::Io)?;
                     let compressed_payload = e.finish().map_err(ProducerError::Io)?;
 
+                    message.uncompressed_size = Some(message.payload.len() as u32);
                     message.payload = compressed_payload;
                     message.compression = Some(2);
                     message
@@ -685,8 +686,9 @@ impl<Exe: Executor> TopicProducer<Exe> {
                 {
                     let compressed_payload =
                         zstd::encode_all(&message.payload[..], 0).map_err(ProducerError::Io)?;
-                    message.compression = Some(3);
+                    message.uncompressed_size = Some(message.payload.len() as u32);
                     message.payload = compressed_payload;
+                    message.compression = Some(3);
                     message
                 }
             }
@@ -712,6 +714,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                         })
                         .map_err(ProducerError::Io)?;
 
+                    message.uncompressed_size = Some(message.payload.len() as u32);
                     message.payload = compressed_payload;
                     message.compression = Some(4);
                     message


### PR DESCRIPTION
This is necessary for compatibility with the pulsar cpp client:
https://github.com/apache/pulsar/blob/6b40749dd4d6be5ea93fc987986a65209c5a8a56/pulsar-client-cpp/lib/ConsumerImpl.cc#L660