### PR TITLE
bump prost to 0.11.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Start Pulsar Standalone Container
         run: docker run --name pulsar -p 6650:6650 -p 8080:8080 -d -e GITHUB_ACTIONS=true -e CI=true streamnative/pulsar:${{ matrix.pulsar-version }} /pulsar/bin/pulsar standalone
 
+      - uses: arduino/setup-protoc@v1
+        name: Install protoc
+        with:
+          version: "3.x"
+
       - uses: actions/checkout@v2
       - name: Build
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsar"
-version = "4.1.1"
+version = "5.0.0"
 edition = "2018"
 authors = [
     "Colin Stearns <cstearns@developers.wyyerd.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ bytes = "1.0.0"
 crc = "3.0.0"
 futures = "0.3"
 nom = { version="7.0.0", default-features=false, features=["alloc"] }
-prost = "0.10.0"
-prost-derive = "0.10.0"
+prost = "0.11.0"
+prost-derive = "0.11.0"
 rand = "0.8"
 chrono = "0.4"
 futures-timer = "3.0"
@@ -59,7 +59,7 @@ env_logger = "0.9"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-prost-build = "0.10.0"
+prost-build = "0.11.0"
 
 [features]
 default = [ "compression", "tokio-runtime", "async-std-runtime", "auth-oauth2" ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features:
 Cargo.toml
 ```toml
 futures = "0.3"
-pulsar = "4.0"
+pulsar = "5.0"
 tokio = "1.0"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```toml
 //! [dependencies]
 //! env_logger = "0.9"
-//! pulsar = "4.1.1"
+//! pulsar = "5.0.0"
 //! serde = { version = "1.0", features = ["derive"] }
 //! serde_json = "1.0"
 //! tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
As title. This is a breaking change and also needs to bump and release new version of pulsar-rs. Not sure whether this PR is the best way to bump dependencies. Thanks for reviewing!