### PR TITLE
fix: Using a weak reference in producers closing callback

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1000,11 +1000,21 @@ impl<Exe: Executor> TopicProducer<Exe> {
         // drop_receiver will return, and we can close the producer
         let (_drop_signal, drop_receiver) = oneshot::channel::<()>();
         let batch = batch_size.map(Batch::new).map(Mutex::new);
-        let conn = self.connection.clone();
+        let conn = Arc::downgrade(&self.connection);
+
         let producer_id = self.id;
         let _ = self.client.executor.spawn(Box::pin(async move {
             let _res = drop_receiver.await;
-            let _ = conn.sender().close_producer(producer_id).await;
+
+            match conn.upgrade() {
+                None => {
+                    debug!("Connection already dropped, no weak reference remaining")
+                }
+                Some(connection) => {
+                    debug!("Closing producers of connection {}", connection.id());
+                    let _ = connection.sender().close_producer(producer_id).await;
+                }
+            }
         }));
 
         self.batch = batch;


### PR DESCRIPTION
**Description**

We're observing some connection that never drop even when the connection is down.

Our assumption is that the Arc::clone keep the reference alive inside the callback.