### PR TITLE
Cleanup travis settings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,35 +8,16 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         pulsar-version: [ 2.8.3.3, 2.9.2.18, 2.10.0.4 ]
-
     steps:
       - name: Start Pulsar Standalone Container
         run: docker run --name pulsar -p 6650:6650 -p 8080:8080 -d -e GITHUB_ACTIONS=true -e CI=true streamnative/pulsar:${{ matrix.pulsar-version }} /pulsar/bin/pulsar standalone
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         run: cargo build --verbose
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: cargo test -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  cargo doc &&
-  echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
-  sudo pip install ghp-import &&
-  ghp-import -n target/doc &&
-  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ documentation = "https://docs.rs/pulsar"
 description = "Rust client for Apache Pulsar"
 keywords = ["pulsar", "api", "client"]
 
-[badges]
-travis-ci = {repository = "wyyerd/pulsar-rs"}
-
 [dependencies]
 bytes = "1.0.0"
 crc = "3.0.0"


### PR DESCRIPTION
The `.travis.yml` stub try to publish the document of our crate. However, crates.io already take a page:

* https://docs.rs/pulsar/4.1.2/pulsar/