### PR TITLE
Implements tracing capabilities through telemetry compiler feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pulsar-version: [ 2.8.3.3, 2.9.2.18, 2.10.0.4 ]
+        pulsar-version: [ 2.8.4.1, 2.9.3.11, 2.10.1.8 ]
     steps:
+      - name: Install protocol buffer compiler
+        uses: arduino/setup-protoc@v1
       - name: Start Pulsar Standalone Container
         run: docker run --name pulsar -p 6650:6650 -p 8080:8080 -d -e GITHUB_ACTIONS=true -e CI=true streamnative/pulsar:${{ matrix.pulsar-version }} /pulsar/bin/pulsar standalone
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ openidconnect = { version = "^2.3.2", optional = true }
 oauth2 = { version = "^4.2.3", optional = true }
 serde = { version = "^1.0.145", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.85", optional = true }
+tracing = { version = "^0.1.36", optional = true }
 async-trait = "^0.1.57"
 data-url = { version = "^0.2.0", optional = true }
 uuid = {version = "^1.1.2", features = ["v4", "fast-rng"] }
@@ -65,3 +66,4 @@ compression = [ "lz4", "flate2", "zstd", "snap" ]
 tokio-runtime = [ "tokio", "tokio-util", "tokio-native-tls" ]
 async-std-runtime = [ "async-std", "asynchronous-codec", "async-native-tls" ]
 auth-oauth2 = [ "openidconnect", "oauth2", "serde", "serde_json", "data-url" ]
+telemetry = ["tracing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,48 +16,48 @@ description = "Rust client for Apache Pulsar"
 keywords = ["pulsar", "api", "client"]
 
 [dependencies]
-bytes = "1.0.0"
-crc = "3.0.0"
-futures = "0.3"
-nom = { version="7.0.0", default-features=false, features=["alloc"] }
-prost = "0.10.0"
-prost-derive = "0.10.0"
-rand = "0.8"
-chrono = "0.4"
-futures-timer = "3.0"
-log = "0.4.6"
-url = "2.1"
-regex = "1.1.7"
-bit-vec = "0.6"
-futures-io = "0.3"
-native-tls = "0.2"
-pem = "1.0.0"
-tokio = { version = "1.0", features = ["rt", "net", "time"], optional = true }
-tokio-util = { version = "0.7", features = ["codec"], optional = true }
-tokio-native-tls = { version = "0.3", optional = true }
-async-std = {version = "1.9", features = [ "attributes", "unstable" ], optional = true }
-asynchronous-codec = { version = "0.6", optional = true }
-async-native-tls = { version = "0.3", optional = true }
-lz4 = { version = "1.23", optional = true }
-flate2 = { version = "1.0", optional = true }
-zstd = { version = "0.11", optional = true }
-snap = { version = "1.0", optional = true }
-openidconnect = { version = "2.1.1", optional = true }
-oauth2 = { version = "4.1", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
-async-trait = "0.1.51"
-data-url = { version = "0.1.1", optional = true }
-uuid = {version = "1.1.2", features = ["v4", "fast-rng"] }
+bytes = "^1.2.1"
+crc = "^3.0.0"
+futures = "^0.3.24"
+nom = { version="^7.1.1", default-features=false, features=["alloc"] }
+prost = "^0.11.0"
+prost-derive = "^0.11.0"
+rand = "^0.8.5"
+chrono = "^0.4.22"
+futures-timer = "^3.0.2"
+log = "^0.4.17"
+url = "^2.3.1"
+regex = "^1.6.0"
+bit-vec = "^0.6.3"
+futures-io = "^0.3.24"
+native-tls = "^0.2.10"
+pem = "^1.1.0"
+tokio = { version = "^1.21.2", features = ["rt", "net", "time"], optional = true }
+tokio-util = { version = "^0.7.4", features = ["codec"], optional = true }
+tokio-native-tls = { version = "^0.3.0", optional = true }
+async-std = {version = "^1.12.0", features = [ "attributes", "unstable" ], optional = true }
+asynchronous-codec = { version = "^0.6.0", optional = true }
+async-native-tls = { version = "^0.4.0", optional = true }
+lz4 = { version = "^1.24.0", optional = true }
+flate2 = { version = "^1.0.24", optional = true }
+zstd = { version = "^0.11.2", optional = true }
+snap = { version = "^1.0.5", optional = true }
+openidconnect = { version = "^2.3.2", optional = true }
+oauth2 = { version = "^4.2.3", optional = true }
+serde = { version = "^1.0.145", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.85", optional = true }
+async-trait = "^0.1.57"
+data-url = { version = "^0.2.0", optional = true }
+uuid = {version = "^1.1.2", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-env_logger = "0.9"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+serde = { version = "^1.0.145", features = ["derive"] }
+serde_json = "^1.0.85"
+env_logger = "^0.9.1"
+tokio = { version = "^1.21.2", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-prost-build = "0.10.0"
+prost-build = "^0.11.1"
 
 [features]
 default = [ "compression", "tokio-runtime", "async-std-runtime", "auth-oauth2" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pulsar"
 version = "4.1.1"
-edition = "2018"
+edition = "2021"
 authors = [
     "Colin Stearns <cstearns@developers.wyyerd.com>",
     "Kevin Stenerson <kstenerson@developers.wyyerd.com>",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Features:
 - automatic reconnection with exponential back off
 - message batching
 - compression with LZ4, zlib, zstd or Snappy (can be deactivated with Cargo features)
+- telemetry using [tracing](https://github.com/tokio-rs/tracing) crate (can be activated with Cargo features)
 
 ### Getting Started
 Cargo.toml

--- a/examples/batching.rs
+++ b/examples/batching.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[macro_use]
 extern crate serde;
 use futures::{future::join_all, TryStreamExt};

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate serde;
 use futures::TryStreamExt;
+use pulsar::authentication::oauth2::OAuth2Authentication;
 use pulsar::{
     Authentication, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
 };
 use std::env;
-use pulsar::authentication::oauth2::{OAuth2Authentication};
 
 #[derive(Serialize, Deserialize)]
 struct TestData {
@@ -43,7 +43,8 @@ async fn main() -> Result<(), pulsar::Error> {
     } else if let Ok(oauth2_cfg) = env::var("PULSAR_OAUTH2") {
         builder = builder.with_auth_provider(OAuth2Authentication::client_credentials(
             serde_json::from_str(oauth2_cfg.as_str())
-                .expect(format!("invalid oauth2 config [{}]", oauth2_cfg.as_str()).as_str())));
+                .unwrap_or_else(|_| panic!("invalid oauth2 config [{}]", oauth2_cfg.as_str())),
+        ));
     }
 
     let pulsar: Pulsar<_> = builder.build().await?;

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[macro_use]
 extern crate serde;
 use futures::TryStreamExt;

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -25,6 +25,7 @@ pub mod token {
 
     impl TokenAuthentication {
         #[allow(clippy::new_ret_no_self)]
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         pub fn new(token: String) -> Rc<dyn Authentication> {
             Rc::new(TokenAuthentication {
                 token: token.into_bytes(),
@@ -34,14 +35,17 @@ pub mod token {
 
     #[async_trait]
     impl Authentication for TokenAuthentication {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn auth_method_name(&self) -> String {
             String::from("token")
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn initialize(&mut self) -> Result<(), AuthenticationError> {
             Ok(())
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn auth_data(&mut self) -> Result<Vec<u8>, AuthenticationError> {
             Ok(self.token.clone())
         }
@@ -87,6 +91,7 @@ pub mod oauth2 {
     }
 
     impl Display for OAuth2Params {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             write!(
                 f,
@@ -103,6 +108,7 @@ pub mod oauth2 {
     }
 
     impl From<BasicTokenResponse> for CachedToken {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn from(resp: BasicTokenResponse) -> Self {
             let now = Instant::now();
             CachedToken {
@@ -114,6 +120,7 @@ pub mod oauth2 {
     }
 
     impl CachedToken {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn is_expiring(&self) -> bool {
             match &self.expiring_at {
                 Some(expiring_at) => Instant::now().ge(expiring_at),
@@ -121,6 +128,7 @@ pub mod oauth2 {
             }
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn is_expired(&self) -> bool {
             match &self.expired_at {
                 Some(expired_at) => Instant::now().ge(expired_at),
@@ -137,6 +145,7 @@ pub mod oauth2 {
     }
 
     impl OAuth2Authentication {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         pub fn client_credentials(params: OAuth2Params) -> Box<dyn Authentication> {
             Box::new(OAuth2Authentication {
                 params,
@@ -148,6 +157,7 @@ pub mod oauth2 {
     }
 
     impl OAuth2Params {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn read_private_params(&self) -> Result<OAuth2PrivateParams, Box<dyn std::error::Error>> {
             let credentials_url = Url::parse(self.credentials_url.as_str())?;
             match credentials_url.scheme() {
@@ -189,10 +199,12 @@ pub mod oauth2 {
 
     #[async_trait]
     impl Authentication for OAuth2Authentication {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn auth_method_name(&self) -> String {
             String::from("token")
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn initialize(&mut self) -> Result<(), AuthenticationError> {
             match self.params.read_private_params() {
                 Ok(private_params) => self.private_params = Some(private_params),
@@ -204,6 +216,7 @@ pub mod oauth2 {
             Ok(())
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn auth_data(&mut self) -> Result<Vec<u8>, AuthenticationError> {
             if self.private_params.is_none() {
                 return Err(AuthenticationError::Custom("not initialized".to_string()));
@@ -242,6 +255,7 @@ pub mod oauth2 {
     }
 
     impl OAuth2Authentication {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn token_url(&mut self) -> Result<Option<TokenUrl>, Box<dyn std::error::Error>> {
             match &self.token_url {
                 Some(url) => Ok(Some(url.clone())),
@@ -265,6 +279,7 @@ pub mod oauth2 {
             }
         }
 
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         async fn fetch_token(&mut self) -> Result<BasicTokenResponse, Box<dyn std::error::Error>> {
             let private_params = self
                 .private_params

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,7 +57,7 @@ impl SerializeMessage for producer::Message {
     }
 }
 
-impl<'a> SerializeMessage for () {
+impl SerializeMessage for () {
     fn serialize_message(_input: Self) -> Result<producer::Message, Error> {
         Ok(producer::Message {
             ..Default::default()
@@ -93,7 +93,7 @@ impl SerializeMessage for String {
     }
 }
 
-impl<'a> SerializeMessage for &String {
+impl<'a> SerializeMessage for &'a String {
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         let payload = input.as_bytes().to_vec();
         Ok(producer::Message {

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,6 +32,7 @@ pub trait DeserializeMessage {
 impl DeserializeMessage for Vec<u8> {
     type Output = Self;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn deserialize_message(payload: &Payload) -> Self::Output {
         payload.data.to_vec()
     }
@@ -40,6 +41,7 @@ impl DeserializeMessage for Vec<u8> {
 impl DeserializeMessage for String {
     type Output = Result<String, FromUtf8Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn deserialize_message(payload: &Payload) -> Self::Output {
         String::from_utf8(payload.data.to_vec())
     }
@@ -52,12 +54,14 @@ pub trait SerializeMessage {
 }
 
 impl SerializeMessage for producer::Message {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         Ok(input)
     }
 }
 
 impl SerializeMessage for () {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(_input: Self) -> Result<producer::Message, Error> {
         Ok(producer::Message {
             ..Default::default()
@@ -66,6 +70,7 @@ impl SerializeMessage for () {
 }
 
 impl<'a> SerializeMessage for &'a [u8] {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         Ok(producer::Message {
             payload: input.to_vec(),
@@ -75,6 +80,7 @@ impl<'a> SerializeMessage for &'a [u8] {
 }
 
 impl SerializeMessage for Vec<u8> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         Ok(producer::Message {
             payload: input,
@@ -84,6 +90,7 @@ impl SerializeMessage for Vec<u8> {
 }
 
 impl SerializeMessage for String {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         let payload = input.into_bytes();
         Ok(producer::Message {
@@ -94,6 +101,7 @@ impl SerializeMessage for String {
 }
 
 impl<'a> SerializeMessage for &'a String {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         let payload = input.as_bytes().to_vec();
         Ok(producer::Message {
@@ -104,6 +112,7 @@ impl<'a> SerializeMessage for &'a String {
 }
 
 impl<'a> SerializeMessage for &'a str {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn serialize_message(input: Self) -> Result<producer::Message, Error> {
         let payload = input.as_bytes().to_vec();
         Ok(producer::Message {
@@ -161,6 +170,7 @@ pub struct Pulsar<Exe: Executor> {
 
 impl<Exe: Executor> Pulsar<Exe> {
     /// creates a new client
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn new<S: Into<String>>(
         url: S,
         auth: Option<Arc<Mutex<Box<dyn crate::authentication::Authentication>>>>,
@@ -234,6 +244,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn builder<S: Into<String>>(url: S, executor: Exe) -> PulsarBuilder<Exe> {
         PulsarBuilder {
             url: url.into(),
@@ -263,6 +274,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn consumer(&self) -> ConsumerBuilder<Exe> {
         ConsumerBuilder::new(self)
     }
@@ -280,6 +292,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn producer(&self) -> ProducerBuilder<Exe> {
         ProducerBuilder::new(self)
     }
@@ -299,6 +312,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn reader(&self) -> ConsumerBuilder<Exe> {
         // this makes it exactly the same like the consumer() method though
         ConsumerBuilder::new(self).with_options(
@@ -316,6 +330,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_topic<S: Into<String>>(&self, topic: S) -> Result<BrokerAddress, Error> {
         self.service_discovery
             .lookup_topic(topic)
@@ -331,6 +346,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_partitioned_topic_number<S: Into<String>>(
         &self,
         topic: S,
@@ -351,6 +367,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_partitioned_topic<S: Into<String>>(
         &self,
         topic: S,
@@ -371,6 +388,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_topics_of_namespace(
         &self,
         namespace: String,
@@ -397,6 +415,7 @@ impl<Exe: Executor> Pulsar<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send<S: Into<String>, M: SerializeMessage + Sized>(
         &self,
         topic: S,
@@ -406,6 +425,7 @@ impl<Exe: Executor> Pulsar<Exe> {
         self.send_raw(message, topic).await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_raw<S: Into<String>>(
         &self,
         message: producer::Message,
@@ -437,10 +457,12 @@ pub struct PulsarBuilder<Exe: Executor> {
 
 impl<Exe: Executor> PulsarBuilder<Exe> {
     /// Authentication parameters (JWT, Biscuit, etc)
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_auth(self, auth: Authentication) -> Self {
         self.with_auth_provider(Box::new(auth))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_auth_provider(
         mut self,
         auth: Box<dyn crate::authentication::Authentication>,
@@ -450,6 +472,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
     }
 
     /// Exponential back off parameters for automatic reconnection
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_connection_retry_options(
         mut self,
         connection_retry_options: ConnectionRetryOptions,
@@ -459,6 +482,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
     }
 
     /// Retry parameters for Pulsar operations
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_operation_retry_options(
         mut self,
         operation_retry_options: OperationRetryOptions,
@@ -468,6 +492,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
     }
 
     /// add a custom certificate chain to authenticate the server in TLS connections
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_certificate_chain(mut self, certificate_chain: Vec<u8>) -> Self {
         match &mut self.tls_options {
             Some(tls) => tls.certificate_chain = Some(certificate_chain),
@@ -481,6 +506,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_allow_insecure_connection(mut self, allow: bool) -> Self {
         match &mut self.tls_options {
             Some(tls) => tls.allow_insecure_connection = allow,
@@ -494,6 +520,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_tls_hostname_verification_enabled(mut self, enabled: bool) -> Self {
         match &mut self.tls_options {
             Some(tls) => tls.tls_hostname_verification_enabled = enabled,
@@ -508,6 +535,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
     }
 
     /// add a custom certificate chain from a file to authenticate the server in TLS connections
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_certificate_chain_file<P: AsRef<std::path::Path>>(
         self,
         path: P,
@@ -522,6 +550,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
     }
 
     /// creates the Pulsar client and connects it
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn build(self) -> Result<Pulsar<Exe>, Error> {
         let PulsarBuilder {
             url,
@@ -550,6 +579,7 @@ struct SendMessage {
     resolver: oneshot::Sender<Result<CommandSendReceipt, Error>>,
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 async fn run_producer<Exe: Executor>(
     client: Pulsar<Exe>,
     mut messages: mpsc::UnboundedReceiver<SendMessage>,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -67,14 +67,17 @@ pub struct Authentication {
 
 #[async_trait]
 impl crate::authentication::Authentication for Authentication {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn auth_method_name(&self) -> String {
         self.name.clone()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn initialize(&mut self) -> Result<(), AuthenticationError> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn auth_data(&mut self) -> Result<Vec<u8>, AuthenticationError> {
         Ok(self.data.clone())
     }
@@ -93,6 +96,7 @@ pub(crate) struct Receiver<S: Stream<Item = Result<Message, ConnectionError>>> {
 }
 
 impl<S: Stream<Item = Result<Message, ConnectionError>>> Receiver<S> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new(
         inbound: S,
         outbound: mpsc::UnboundedSender<Message>,
@@ -117,6 +121,7 @@ impl<S: Stream<Item = Result<Message, ConnectionError>>> Receiver<S> {
 impl<S: Stream<Item = Result<Message, ConnectionError>>> Future for Receiver<S> {
     type Output = Result<(), ()>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.shutdown.as_mut().poll(cx) {
             Poll::Ready(Ok(())) | Poll::Ready(Err(futures::channel::oneshot::Canceled)) => {
@@ -238,15 +243,19 @@ impl<S: Stream<Item = Result<Message, ConnectionError>>> Future for Receiver<S> 
 pub struct SerialId(Arc<AtomicUsize>);
 
 impl Default for SerialId {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn default() -> Self {
         SerialId(Arc::new(AtomicUsize::new(0)))
     }
 }
 
 impl SerialId {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new() -> Self {
         Self::default()
     }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn get(&self) -> u64 {
         self.0.fetch_add(1, Ordering::Relaxed) as u64
     }
@@ -266,6 +275,7 @@ pub struct ConnectionSender<Exe: Executor> {
 }
 
 impl<Exe: Executor> ConnectionSender<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) fn new(
         connection_id: Uuid,
         tx: mpsc::UnboundedSender<Message>,
@@ -288,6 +298,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn send(
         &self,
         producer_id: u64,
@@ -304,6 +315,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
             .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send_ping(&self) -> Result<(), ConnectionError> {
         let (resolver, response) = oneshot::channel();
         trace!("sending ping to connection {}", self.connection_id);
@@ -341,6 +353,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_topic<S: Into<String>>(
         &self,
         topic: S,
@@ -354,6 +367,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_partitioned_topic<S: Into<String>>(
         &self,
         topic: S,
@@ -366,6 +380,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_consumer_stats(
         &self,
         consumer_id: u64,
@@ -377,6 +392,8 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         })
         .await
     }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_last_message_id(
         &self,
         consumer_id: u64,
@@ -389,6 +406,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn create_producer(
         &self,
         topic: String,
@@ -404,6 +422,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn wait_for_exclusive_access(
         &self,
         request_id: u64,
@@ -414,6 +433,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_topics_of_namespace(
         &self,
         namespace: String,
@@ -427,6 +447,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn close_producer(
         &self,
         producer_id: u64,
@@ -439,6 +460,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn subscribe(
         &self,
         resolver: mpsc::UnboundedSender<Message>,
@@ -475,12 +497,14 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn send_flow(&self, consumer_id: u64, message_permits: u32) -> Result<(), ConnectionError> {
         self.tx
             .unbounded_send(messages::flow(consumer_id, message_permits))
             .map_err(|_| ConnectionError::Disconnected)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn send_ack(
         &self,
         consumer_id: u64,
@@ -492,6 +516,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
             .map_err(|_| ConnectionError::Disconnected)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn send_redeliver_unacknowleged_messages(
         &self,
         consumer_id: u64,
@@ -505,6 +530,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
             .map_err(|_| ConnectionError::Disconnected)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn close_consumer(
         &self,
         consumer_id: u64,
@@ -517,6 +543,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn seek(
         &self,
         consumer_id: u64,
@@ -531,6 +558,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn unsubscribe(
         &self,
         consumer_id: u64,
@@ -543,6 +571,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         .await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_message<R: Debug, F>(
         &self,
         msg: Message,
@@ -618,6 +647,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
     }
 
     /// wait for desired message(commandproducersuccess with ready field true)
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn wait_exclusive_access<R: Debug, F>(
         &self,
         key: RequestKey,
@@ -663,6 +693,7 @@ pub struct Connection<Exe: Executor> {
 }
 
 impl<Exe: Executor> Connection<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn new(
         url: Url,
         auth_data: Option<Arc<Mutex<Box<dyn crate::authentication::Authentication>>>>,
@@ -754,6 +785,7 @@ impl<Exe: Executor> Connection<Exe> {
         Ok(Connection { id, url, sender })
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn prepare_auth_data(
         auth: Option<Arc<Mutex<Box<dyn crate::authentication::Authentication>>>>,
     ) -> Result<Option<Authentication>, ConnectionError> {
@@ -769,6 +801,7 @@ impl<Exe: Executor> Connection<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn prepare_stream(
         connection_id: Uuid,
         address: SocketAddr,
@@ -881,6 +914,7 @@ impl<Exe: Executor> Connection<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn connect<S>(
         connection_id: Uuid,
         mut stream: S,
@@ -980,29 +1014,35 @@ impl<Exe: Executor> Connection<Exe> {
         Ok(sender)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn id(&self) -> Uuid {
         self.id
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn error(&self) -> Option<ConnectionError> {
         self.sender.error.remove()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn is_valid(&self) -> bool {
         !self.sender.error.is_set()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn url(&self) -> &Url {
         &self.url
     }
 
     /// Chain to send a message, e.g. conn.sender().send_ping()
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn sender(&self) -> &ConnectionSender<Exe> {
         &self.sender
     }
 }
 
 impl<Exe: Executor> Drop for Connection<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn drop(&mut self) {
         trace!("dropping connection {} for {}", self.id, self.url);
         if let Some(shutdown) = self.sender.receiver_shutdown.take() {
@@ -1011,6 +1051,7 @@ impl<Exe: Executor> Drop for Connection<Exe> {
     }
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn extract_message<T: Debug, F>(message: Message, extract: F) -> Result<T, ConnectionError>
 where
     F: FnOnce(Message) -> Option<T>,
@@ -1043,6 +1084,7 @@ pub(crate) mod messages {
     };
     use crate::producer::{self, ProducerOptions};
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn connect(auth: Option<Authentication>, proxy_to_broker_url: Option<String>) -> Message {
         let (auth_method_name, auth_data) = match auth {
             Some(auth) => (Some(auth.name), Some(auth.data)),
@@ -1066,6 +1108,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn ping() -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1077,6 +1120,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn pong() -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1088,6 +1132,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn create_producer(
         topic: String,
         producer_name: Option<String>,
@@ -1122,6 +1167,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn get_topics_of_namespace(
         request_id: u64,
         namespace: String,
@@ -1142,6 +1188,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) fn send(
         producer_id: u64,
         producer_name: String,
@@ -1190,6 +1237,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn lookup_topic(topic: String, authoritative: bool, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1206,6 +1254,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn lookup_partitioned_topic(topic: String, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1221,6 +1270,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn consumer_stats(request_id: u64, consumer_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1234,6 +1284,8 @@ pub(crate) mod messages {
             payload: None,
         }
     }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn get_last_message_id(consumer_id: u64, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1248,6 +1300,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn close_producer(producer_id: u64, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1262,6 +1315,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn subscribe(
         topic: String,
         subscription: String,
@@ -1303,6 +1357,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn flow(consumer_id: u64, message_permits: u32) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1317,6 +1372,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn ack(
         consumer_id: u64,
         message_id: Vec<proto::MessageIdData>,
@@ -1343,6 +1399,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn redeliver_unacknowleged_messages(
         consumer_id: u64,
         message_ids: Vec<proto::MessageIdData>,
@@ -1363,6 +1420,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn close_consumer(consumer_id: u64, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {
@@ -1377,6 +1435,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn seek(
         consumer_id: u64,
         request_id: u64,
@@ -1398,6 +1457,7 @@ pub(crate) mod messages {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn unsubscribe(consumer_id: u64, request_id: u64) -> Message {
         Message {
             command: proto::BaseCommand {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -38,6 +38,7 @@ pub struct ConnectionRetryOptions {
 }
 
 impl std::default::Default for ConnectionRetryOptions {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn default() -> Self {
         ConnectionRetryOptions {
             min_backoff: Duration::from_millis(10),
@@ -61,6 +62,7 @@ pub struct OperationRetryOptions {
 }
 
 impl std::default::Default for OperationRetryOptions {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn default() -> Self {
         OperationRetryOptions {
             operation_timeout: Duration::from_secs(30),
@@ -88,6 +90,7 @@ pub struct TlsOptions {
 }
 
 impl Default for TlsOptions {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn default() -> Self {
         Self {
             certificate_chain: None,
@@ -120,6 +123,7 @@ pub struct ConnectionManager<Exe: Executor> {
 }
 
 impl<Exe: Executor> ConnectionManager<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn new(
         url: String,
         auth: Option<Arc<Mutex<Box<dyn crate::authentication::Authentication>>>>,
@@ -199,6 +203,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
     /// get an active Connection from a broker address
     ///
     /// creates a connection if not available
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_base_connection(&self) -> Result<Arc<Connection<Exe>>, ConnectionError> {
         let broker_address = self.get_base_address();
         self.get_connection(&broker_address).await
@@ -207,6 +212,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
     /// get an active Connection from a broker address
     ///
     /// creates a connection if not available
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_connection(
         &self,
         broker: &BrokerAddress,
@@ -239,6 +245,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn connect_inner(
         &self,
         broker: &BrokerAddress,
@@ -357,6 +364,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         Ok(c)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn connect(
         &self,
         broker: BrokerAddress,
@@ -461,6 +469,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
     }
 
     /// tests that all connections are valid and still used
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn check_connections(&self) {
         trace!("cleaning invalid or unused connections");
         self.connections

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -64,36 +64,43 @@ pub struct ConsumerOptions {
 
 impl ConsumerOptions {
     /// within options, sets the priority level
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_priority_level(mut self, priority_level: i32) -> Self {
         self.priority_level = Some(priority_level);
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn durable(mut self, durable: bool) -> Self {
         self.durable = Some(durable);
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn starting_on_message(mut self, message_id_data: MessageIdData) -> Self {
         self.start_message_id = Some(message_id_data);
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_metadata(mut self, metadata: BTreeMap<String, String>) -> Self {
         self.metadata = metadata;
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn read_compacted(mut self, read_compacted: bool) -> Self {
         self.read_compacted = Some(read_compacted);
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_schema(mut self, schema: Schema) -> Self {
         self.schema = Some(schema);
         self
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_initial_position(mut self, initial_position: InitialPosition) -> Self {
         self.initial_position = initial_position;
         self
@@ -118,11 +125,14 @@ pub enum InitialPosition {
 }
 
 impl Default for InitialPosition {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn default() -> Self {
         InitialPosition::Latest
     }
 }
+
 impl From<InitialPosition> for i32 {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(i: InitialPosition) -> Self {
         match i {
             InitialPosition::Earliest => 1,
@@ -168,13 +178,16 @@ impl From<InitialPosition> for i32 {
 pub struct Consumer<T: DeserializeMessage, Exe: Executor> {
     inner: InnerConsumer<T, Exe>,
 }
+
 impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     /// creates a [ConsumerBuilder] from a client instance
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn builder(pulsar: &Pulsar<Exe>) -> ConsumerBuilder<Exe> {
         ConsumerBuilder::new(pulsar)
     }
 
     /// test that the connections to the Pulsar brokers are still valid
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn check_connection(&mut self) -> Result<(), Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.check_connection().await,
@@ -183,6 +196,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// get consumer stats
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_stats(&mut self) -> Result<Vec<CommandConsumerStatsResponse>, Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => Ok(vec![c.get_stats().await?]),
@@ -191,6 +205,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a single message
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.ack(msg).await,
@@ -199,6 +214,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a message and all the preceding messages
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.cumulative_ack(msg).await,
@@ -209,6 +225,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     /// negative acknowledgement
     ///
     /// the message will be sent again on the subscription
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn nack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.nack(msg).await,
@@ -219,6 +236,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     /// seek currently destroys the existing consumer and creates a new one
     /// this is how java and cpp pulsar client implement this feature mainly because
     /// there are many minor problems with flushing existing messages and receiving new ones
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn seek(
         &mut self,
         consumer_ids: Option<Vec<String>>,
@@ -279,6 +297,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn unsubscribe(&mut self) -> Result<(), Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.unsubscribe().await,
@@ -286,6 +305,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_last_message_id(&mut self) -> Result<Vec<MessageIdData>, Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => Ok(vec![c.get_last_message_id().await?]),
@@ -294,6 +314,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the list of topics this consumer is subscribed on
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn topics(&self) -> Vec<String> {
         match &self.inner {
             InnerConsumer::Single(c) => vec![c.topic()],
@@ -302,6 +323,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns a list of broker URLs this consumer is connnected to
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn connections(&mut self) -> Result<Vec<Url>, Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => Ok(vec![c.connection().await?.url().clone()]),
@@ -324,6 +346,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's configuration options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn options(&self) -> &ConsumerOptions {
         match &self.inner {
             InnerConsumer::Single(c) => &c.config.options,
@@ -332,6 +355,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's dead letter policy options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn dead_letter_policy(&self) -> Option<&DeadLetterPolicy> {
         match &self.inner {
             InnerConsumer::Single(c) => c.dead_letter_policy.as_ref(),
@@ -340,6 +364,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's subscription name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn subscription(&self) -> &str {
         match &self.inner {
             InnerConsumer::Single(c) => &c.config.subscription,
@@ -348,6 +373,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's subscription type
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn sub_type(&self) -> SubType {
         match &self.inner {
             InnerConsumer::Single(c) => c.config.sub_type,
@@ -356,6 +382,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's batch size
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn batch_size(&self) -> Option<u32> {
         match &self.inner {
             InnerConsumer::Single(c) => c.config.batch_size,
@@ -364,6 +391,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn consumer_name(&self) -> Option<&str> {
         match &self.inner {
             InnerConsumer::Single(c) => &c.config.consumer_name,
@@ -374,6 +402,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the consumer's list of ids
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn consumer_id(&self) -> Vec<u64> {
         match &self.inner {
             InnerConsumer::Single(c) => vec![c.consumer_id],
@@ -385,6 +414,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     ///
     /// if messages are not acknowledged before this delay, they will be sent
     /// again on the subscription
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn unacked_message_redelivery_delay(&self) -> Option<Duration> {
         match &self.inner {
             InnerConsumer::Single(c) => c.config.unacked_message_redelivery_delay,
@@ -393,6 +423,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the date of the last message reception
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn last_message_received(&self) -> Option<DateTime<Utc>> {
         match &self.inner {
             InnerConsumer::Single(c) => c.last_message_received(),
@@ -401,6 +432,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// returns the current number of messages received
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn messages_received(&self) -> u64 {
         match &self.inner {
             InnerConsumer::Single(c) => c.messages_received(),
@@ -413,6 +445,7 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
 impl<T: DeserializeMessage + 'static, Exe: Executor> Stream for Consumer<T, Exe> {
     type Item = Result<Message<T>, Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match &mut self.inner {
             InnerConsumer::Single(c) => Pin::new(c).poll_next(cx),
@@ -443,6 +476,7 @@ pub(crate) struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
 }
 
 impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn new(
         client: Pulsar<Exe>,
         topic: String,
@@ -628,10 +662,12 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         })
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn topic(&self) -> String {
         self.topic.clone()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn connection(&mut self) -> Result<Arc<Connection<Exe>>, Error> {
         let (resolver, response) = oneshot::channel();
         self.engine_tx
@@ -645,6 +681,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         })
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_stats(&mut self) -> Result<CommandConsumerStatsResponse, Error> {
         let consumer_id = self.consumer_id;
         let conn = self.connection().await?;
@@ -652,6 +689,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(consumer_stats_response)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn check_connection(&mut self) -> Result<(), Error> {
         let conn = self.connection().await?;
         info!("check connection for id {}", conn.id());
@@ -659,6 +697,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
             .send(EngineMessage::Ack(msg.message_id.clone(), false))
@@ -666,10 +705,12 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) fn acker(&self) -> mpsc::UnboundedSender<EngineMessage<Exe>> {
         self.engine_tx.clone()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
             .send(EngineMessage::Ack(msg.message_id.clone(), true))
@@ -677,6 +718,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn nack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
             .send(EngineMessage::Nack(msg.message_id.clone()))
@@ -684,6 +726,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn seek(
         &mut self,
         message_id: Option<MessageIdData>,
@@ -698,6 +741,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn unsubscribe(&mut self) -> Result<(), Error> {
         let consumer_id = self.consumer_id;
         self.connection()
@@ -708,6 +752,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_last_message_id(&mut self) -> Result<MessageIdData, Error> {
         let consumer_id = self.consumer_id;
         let conn = self.connection().await?;
@@ -715,18 +760,22 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         Ok(get_last_message_id_response.last_message_id)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn last_message_received(&self) -> Option<DateTime<Utc>> {
         self.last_message_received
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn messages_received(&self) -> u64 {
         self.messages_received
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn config(&self) -> &ConsumerConfig {
         &self.config
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn create_message(&self, message_id: proto::MessageIdData, payload: Payload) -> Message<T> {
         Message {
             topic: self.topic.clone(),
@@ -743,6 +792,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
 impl<T: DeserializeMessage, Exe: Executor> Stream for TopicConsumer<T, Exe> {
     type Item = Result<Message<T>, Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.messages.as_mut().poll_next(cx) {
             Poll::Pending => Poll::Pending,
@@ -785,6 +835,7 @@ pub(crate) enum EngineMessage<Exe: Executor> {
 }
 
 impl<Exe: Executor> ConsumerEngine<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn new(
         client: Pulsar<Exe>,
         connection: Arc<Connection<Exe>>,
@@ -822,7 +873,8 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             _drop_signal,
         }
     }
-
+    
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn engine(&mut self) -> Result<(), Error> {
         debug!("starting the consumer engine for topic {}", self.topic);
         let mut messages_or_ack_f = None;
@@ -986,6 +1038,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn ack(&mut self, message_id: MessageData, cumulative: bool) {
         //FIXME: this does not handle cumulative acks
         self.unacked_messages.remove(&message_id.id);
@@ -999,6 +1052,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
     }
 
     /// Process the message. Returns `true` if there are more messages to process
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn process_message(&mut self, message: RawMessage) -> Result<bool, Error> {
         match message {
             RawMessage {
@@ -1076,6 +1130,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         Ok(true)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn process_payload(
         &mut self,
         message: CommandMessage,
@@ -1225,6 +1280,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_to_consumer(
         &mut self,
         message_id: MessageIdData,
@@ -1244,6 +1300,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn reconnect(&mut self) -> Result<(), Error> {
         debug!("reconnecting consumer for topic: {}", self.topic);
         let broker_address = self.client.lookup_topic(&self.topic).await?;
@@ -1305,6 +1362,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn debug_format(&self) -> String {
         format!(
             "[{id} - {subscription}{name}: {topic}]",
@@ -1335,6 +1393,7 @@ struct BatchedMessageIterator {
 }
 
 impl BatchedMessageIterator {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn new(message_id: proto::MessageIdData, payload: Payload) -> Result<Self, ConnectionError> {
         let total_messages = payload
             .metadata
@@ -1355,6 +1414,7 @@ impl BatchedMessageIterator {
 impl Iterator for BatchedMessageIterator {
     type Item = (proto::MessageIdData, Payload);
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn next(&mut self) -> Option<Self::Item> {
         let remaining = self.total_messages - self.current_index;
         if remaining == 0 {
@@ -1409,6 +1469,7 @@ pub struct ConsumerBuilder<Exe: Executor> {
 
 impl<Exe: Executor> ConsumerBuilder<Exe> {
     /// Creates a new [ConsumerBuilder] from an existing client instance
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new(pulsar: &Pulsar<Exe>) -> Self {
         ConsumerBuilder {
             pulsar: pulsar.clone(),
@@ -1429,6 +1490,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     }
 
     /// sets the consumer's topic or add one to the list of topics
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic<S: Into<String>>(mut self, topic: S) -> ConsumerBuilder<Exe> {
         match &mut self.topics {
             Some(topics) => topics.push(topic.into()),
@@ -1438,6 +1500,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     }
 
     /// adds a list of topics to the future consumer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topics<S: AsRef<str>, I: IntoIterator<Item = S>>(
         mut self,
         topics: I,
@@ -1454,18 +1517,21 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
 
     /// sets up a consumer that will listen on all topics matching the regular
     /// expression
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic_regex(mut self, regex: Regex) -> ConsumerBuilder<Exe> {
         self.topic_regex = Some(regex);
         self
     }
 
     /// sets the subscription's name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_subscription<S: Into<String>>(mut self, subscription: S) -> Self {
         self.subscription = Some(subscription.into());
         self
     }
 
     /// sets the kind of subscription
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_subscription_type(mut self, subscription_type: SubType) -> Self {
         self.subscription_type = Some(subscription_type);
         self
@@ -1475,24 +1541,28 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     /// specify namespace using the `<persistent|non-persistent://<tenant>/<namespace>/<topic>`
     /// topic format.
     /// Defaults to `public/default` if not specifid
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_lookup_namespace<S: Into<String>>(mut self, namespace: S) -> Self {
         self.namespace = Some(namespace.into());
         self
     }
 
     /// Interval for refreshing the topics when using a topic regex. Unused otherwise.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic_refresh(mut self, refresh_interval: Duration) -> Self {
         self.topic_refresh = Some(refresh_interval);
         self
     }
 
     /// sets the consumer id for this consumer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_consumer_id(mut self, consumer_id: u64) -> Self {
         self.consumer_id = Some(consumer_id);
         self
     }
 
     /// sets the consumer's name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_consumer_name<S: Into<String>>(mut self, consumer_name: S) -> Self {
         self.consumer_name = Some(consumer_name.into());
         self
@@ -1504,18 +1574,21 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     /// not be sent by Pulsar
     ///
     /// default value: 1000
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_batch_size(mut self, batch_size: u32) -> Self {
         self.batch_size = Some(batch_size);
         self
     }
 
     /// sets consumer options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_options(mut self, options: ConsumerOptions) -> Self {
         self.consumer_options = Some(options);
         self
     }
 
     /// sets the dead letter policy
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_dead_letter_policy(mut self, dead_letter_policy: DeadLetterPolicy) -> Self {
         self.dead_letter_policy = Some(dead_letter_policy);
         self
@@ -1524,6 +1597,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     /// The time after which a message is dropped without being acknowledged or nacked
     /// that the message is resent. If `None`, messages will only be resent when a
     /// consumer disconnects with pending unacknowledged messages.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_unacked_message_resend_delay(mut self, delay: Option<Duration>) -> Self {
         self.unacked_message_resend_delay = delay;
         self
@@ -1531,6 +1605,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
 
     // Checks the builder for inconsistencies
     // returns a config and a list of topics with associated brokers
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn validate<T: DeserializeMessage>(
         self,
     ) -> Result<(ConsumerConfig, Vec<(String, BrokerAddress)>), Error> {
@@ -1620,6 +1695,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     }
 
     /// creates a [Consumer] from this builder
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn build<T: DeserializeMessage>(self) -> Result<Consumer<T, Exe>, Error> {
         // would this clone() consume too much memory?
         let (config, joined_topics) = self.clone().validate::<T>().await?;
@@ -1667,6 +1743,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
     }
 
     /// creates a [Reader] from this builder
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn into_reader<T: DeserializeMessage>(self) -> Result<Reader<T, Exe>, Error> {
         // would this clone() consume too much memory?
         let (mut config, mut joined_topics) = self.clone().validate::<T>().await?;
@@ -1735,15 +1812,18 @@ struct MultiTopicConsumer<T: DeserializeMessage, Exe: Executor> {
 }
 
 impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn topics(&self) -> Vec<String> {
         self.topics.iter().map(|s| s.to_string()).collect()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn get_stats(&mut self) -> Result<Vec<CommandConsumerStatsResponse>, Error> {
         let resposnes = try_join_all(self.consumers.values_mut().map(|c| c.get_stats())).await?;
         Ok(resposnes)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn last_message_received(&self) -> Option<DateTime<Utc>> {
         self.consumers
             .values()
@@ -1752,6 +1832,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             .max()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn messages_received(&self) -> u64 {
         self.consumers
             .values()
@@ -1760,6 +1841,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             .sum()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn check_connections(&mut self) -> Result<(), Error> {
         self.pulsar
             .manager
@@ -1776,12 +1858,14 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn get_last_message_id(&mut self) -> Result<Vec<MessageIdData>, Error> {
         let responses =
             try_join_all(self.consumers.values_mut().map(|c| c.get_last_message_id())).await?;
         Ok(responses)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn unsubscribe(&mut self) -> Result<(), Error> {
         for consumer in self.consumers.values_mut() {
             consumer.unsubscribe().await?;
@@ -1790,6 +1874,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn add_consumers<I: IntoIterator<Item = TopicConsumer<T, Exe>>>(&mut self, consumers: I) {
         for consumer in consumers {
             let topic = consumer.topic().to_owned();
@@ -1798,6 +1883,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn remove_consumers(&mut self, topics: &[String]) {
         self.topics.retain(|t| !topics.contains(t));
         for topic in topics {
@@ -1812,6 +1898,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn update_topics(&mut self) {
         if let Some(regex) = self.topic_regex.clone() {
             let pulsar = self.pulsar.clone();
@@ -1856,6 +1943,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(&msg.topic) {
             c.ack(msg).await
@@ -1864,6 +1952,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(&msg.topic) {
             c.cumulative_ack(msg).await
@@ -1872,6 +1961,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn nack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(&msg.topic) {
             c.nack(msg).await?;
@@ -1882,6 +1972,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     /// Assume that this seek method will call seek for the topics given in the consumer_ids
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn seek(
         &mut self,
         consumer_ids: Option<Vec<String>>,
@@ -1915,6 +2006,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn config(&self) -> &ConsumerConfig {
         &self.config
     }
@@ -1935,28 +2027,33 @@ pub struct Message<T> {
 
 impl<T> Message<T> {
     /// Pulsar metadata for the message
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn metadata(&self) -> &MessageMetadata {
         &self.payload.metadata
     }
 
     /// Get Pulsar message id for the message
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn message_id(&self) -> &proto::MessageIdData {
         &self.message_id.id
     }
 
     /// Get message key (partition key)
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn key(&self) -> Option<String> {
         self.payload.metadata.partition_key.clone()
     }
 }
 impl<T: DeserializeMessage> Message<T> {
     /// directly deserialize a message
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn deserialize(&self) -> T::Output {
         T::deserialize_message(&self.payload)
     }
 }
 
 impl<T: DeserializeMessage, Exe: Executor> Debug for MultiTopicConsumer<T, Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -1969,6 +2066,7 @@ impl<T: DeserializeMessage, Exe: Executor> Debug for MultiTopicConsumer<T, Exe> 
 impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsumer<T, Exe> {
     type Item = Result<Message<T>, Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(mut new_consumers) = self.new_consumers.take() {
             match new_consumers.as_mut().poll(cx) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,30 +17,35 @@ pub enum Error {
 }
 
 impl From<ConnectionError> for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ConnectionError) -> Self {
         Error::Connection(err)
     }
 }
 
 impl From<ConsumerError> for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ConsumerError) -> Self {
         Error::Consumer(err)
     }
 }
 
 impl From<ProducerError> for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ProducerError) -> Self {
         Error::Producer(err)
     }
 }
 
 impl From<ServiceDiscoveryError> for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ServiceDiscoveryError) -> Self {
         Error::ServiceDiscovery(err)
     }
 }
 
 impl fmt::Display for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Connection(e) => write!(f, "Connection error: {}", e),
@@ -55,6 +60,7 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Connection(e) => e.source(),
@@ -86,24 +92,28 @@ pub enum ConnectionError {
 }
 
 impl From<io::Error> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: io::Error) -> Self {
         ConnectionError::Io(err)
     }
 }
 
 impl From<native_tls::Error> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: native_tls::Error) -> Self {
         ConnectionError::Tls(err)
     }
 }
 
 impl From<AuthenticationError> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: AuthenticationError) -> Self {
         ConnectionError::Authentication(err)
     }
 }
 
 impl fmt::Display for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ConnectionError::Io(e) => write!(f, "{}", e),
@@ -128,6 +138,7 @@ impl fmt::Display for ConnectionError {
 }
 
 impl std::error::Error for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ConnectionError::Io(e) => Some(e),
@@ -147,18 +158,21 @@ pub enum ConsumerError {
 }
 
 impl From<ConnectionError> for ConsumerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ConnectionError) -> Self {
         ConsumerError::Connection(err)
     }
 }
 
 impl From<io::Error> for ConsumerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: io::Error) -> Self {
         ConsumerError::Io(err)
     }
 }
 
 impl From<futures::channel::mpsc::SendError> for ConsumerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: futures::channel::mpsc::SendError) -> Self {
         if err.is_full() {
             ConsumerError::ChannelFull
@@ -169,6 +183,7 @@ impl From<futures::channel::mpsc::SendError> for ConsumerError {
 }
 
 impl fmt::Display for ConsumerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ConsumerError::Connection(e) => write!(f, "Connection error: {}", e),
@@ -188,6 +203,7 @@ impl fmt::Display for ConsumerError {
 }
 
 impl std::error::Error for ConsumerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ConsumerError::Connection(e) => Some(e),
@@ -208,18 +224,21 @@ pub enum ProducerError {
 }
 
 impl From<ConnectionError> for ProducerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ConnectionError) -> Self {
         ProducerError::Connection(err)
     }
 }
 
 impl From<io::Error> for ProducerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: io::Error) -> Self {
         ProducerError::Io(err)
     }
 }
 
 impl fmt::Display for ProducerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ProducerError::Connection(e) => write!(f, "Connection error: {}", e),
@@ -255,6 +274,7 @@ impl fmt::Display for ProducerError {
 }
 
 impl fmt::Debug for ProducerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ProducerError::Connection(e) => write!(f, "Connection({:?})", e),
@@ -280,6 +300,7 @@ impl fmt::Debug for ProducerError {
 }
 
 impl std::error::Error for ProducerError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ProducerError::Connection(e) => Some(e),
@@ -307,12 +328,14 @@ pub enum ServiceDiscoveryError {
 }
 
 impl From<ConnectionError> for ServiceDiscoveryError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: ConnectionError) -> Self {
         ServiceDiscoveryError::Connection(err)
     }
 }
 
 impl fmt::Display for ServiceDiscoveryError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ServiceDiscoveryError::Connection(e) => write!(f, "Connection error: {}", e),
@@ -329,6 +352,7 @@ impl fmt::Display for ServiceDiscoveryError {
 }
 
 impl std::error::Error for ServiceDiscoveryError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ServiceDiscoveryError::Connection(e) => Some(e),
@@ -343,6 +367,7 @@ pub enum AuthenticationError {
 }
 
 impl fmt::Display for AuthenticationError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AuthenticationError::Custom(m) => write!(f, "authentication error [{}]", m),
@@ -359,6 +384,7 @@ pub(crate) struct SharedError {
 }
 
 impl SharedError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new() -> SharedError {
         SharedError {
             error_set: Arc::new(AtomicBool::new(false)),
@@ -366,10 +392,12 @@ impl SharedError {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn is_set(&self) -> bool {
         self.error_set.load(Ordering::Relaxed)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn remove(&self) -> Option<ConnectionError> {
         let mut lock = self.error.lock().unwrap();
         let error = lock.take();
@@ -377,6 +405,7 @@ impl SharedError {
         error
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn set(&self, error: ConnectionError) {
         let mut lock = self.error.lock().unwrap();
         *lock = Some(error);
@@ -387,6 +416,7 @@ impl SharedError {
 use crate::message::proto::ServerError;
 use crate::producer::SendFuture;
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 pub(crate) fn server_error(i: i32) -> Option<ServerError> {
     match i {
         0 => Some(ServerError::UnknownError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -273,7 +273,7 @@ impl fmt::Debug for ProducerError {
                     }
                 }
                 write!(f, ")")
-            }, 
+            }
             ProducerError::Fenced => write!(f, "Producer is fenced"),
         }
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -18,6 +18,7 @@ pub trait Executor: Clone + Send + Sync + 'static {
     /// spawns a new task
     #[allow(clippy::result_unit_err)]
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
+
     /// spawns a new blocking task
     fn spawn_blocking<F, Res>(&self, f: F) -> JoinHandle<Res>
     where
@@ -26,6 +27,7 @@ pub trait Executor: Clone + Send + Sync + 'static {
 
     /// returns a Stream that will produce at regular intervals
     fn interval(&self, duration: std::time::Duration) -> Interval;
+
     /// waits for a configurable time
     fn delay(&self, duration: std::time::Duration) -> Delay;
 
@@ -43,11 +45,13 @@ pub struct TokioExecutor;
 
 #[cfg(feature = "tokio-runtime")]
 impl Executor for TokioExecutor {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         tokio::task::spawn(f);
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn_blocking<F, Res>(&self, f: F) -> JoinHandle<Res>
     where
         F: FnOnce() -> Res + Send + 'static,
@@ -56,14 +60,17 @@ impl Executor for TokioExecutor {
         JoinHandle::Tokio(tokio::task::spawn_blocking(f))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn interval(&self, duration: std::time::Duration) -> Interval {
         Interval::Tokio(tokio::time::interval(duration))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn delay(&self, duration: std::time::Duration) -> Delay {
         Delay::Tokio(tokio::time::sleep(duration))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn kind(&self) -> ExecutorKind {
         ExecutorKind::Tokio
     }
@@ -76,11 +83,13 @@ pub struct AsyncStdExecutor;
 
 #[cfg(feature = "async-std-runtime")]
 impl Executor for AsyncStdExecutor {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         async_std::task::spawn(f);
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn_blocking<F, Res>(&self, f: F) -> JoinHandle<Res>
     where
         F: FnOnce() -> Res + Send + 'static,
@@ -89,25 +98,30 @@ impl Executor for AsyncStdExecutor {
         JoinHandle::AsyncStd(async_std::task::spawn_blocking(f))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn interval(&self, duration: std::time::Duration) -> Interval {
         Interval::AsyncStd(async_std::stream::interval(duration))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn delay(&self, duration: std::time::Duration) -> Delay {
         use async_std::prelude::FutureExt;
         Delay::AsyncStd(Box::pin(async_std::future::ready(()).delay(duration)))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn kind(&self) -> ExecutorKind {
         ExecutorKind::AsyncStd
     }
 }
 
 impl<Exe: Executor> Executor for Arc<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()> {
         self.deref().spawn(f)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn spawn_blocking<F, Res>(&self, f: F) -> JoinHandle<Res>
     where
         F: FnOnce() -> Res + Send + 'static,
@@ -116,14 +130,17 @@ impl<Exe: Executor> Executor for Arc<Exe> {
         self.deref().spawn_blocking(f)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn interval(&self, duration: std::time::Duration) -> Interval {
         self.deref().interval(duration)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn delay(&self, duration: std::time::Duration) -> Delay {
         self.deref().delay(duration)
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn kind(&self) -> ExecutorKind {
         self.deref().kind()
     }
@@ -146,6 +163,7 @@ use std::task::Poll;
 impl<T> Future for JoinHandle<T> {
     type Output = Option<T>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> std::task::Poll<Self::Output> {
         match self.get_mut() {
             #[cfg(feature = "tokio-runtime")]
@@ -181,6 +199,7 @@ pub enum Interval {
 impl Stream for Interval {
     type Item = ();
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context,
@@ -219,6 +238,7 @@ pub enum Delay {
 impl Future for Delay {
     type Output = ();
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> std::task::Poll<Self::Output> {
         unsafe {
             match Pin::get_unchecked_mut(self) {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -16,7 +16,7 @@ pub enum ExecutorKind {
 /// Wrapper trait abstracting the Tokio and async-std executors
 pub trait Executor: Clone + Send + Sync + 'static {
     /// spawns a new task
-    #[allow(clippy::clippy::result_unit_err)]
+    #[allow(clippy::result_unit_err)]
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) -> Result<(), ()>;
     /// spawns a new blocking task
     fn spawn_blocking<F, Res>(&self, f: F) -> JoinHandle<Res>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ pub use message::{
 };
 pub use producer::{MultiTopicProducer, Producer, ProducerOptions};
 
+pub mod authentication;
 mod client;
 mod connection;
 mod connection_manager;
@@ -185,7 +186,6 @@ pub mod executor;
 pub mod message;
 pub mod producer;
 pub mod reader;
-pub mod authentication;
 mod service_discovery;
 
 #[cfg(test)]
@@ -306,8 +306,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "tokio-runtime")]
     async fn round_trip() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
 
         let addr = "pulsar://127.0.0.1:6650";
         let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
@@ -371,8 +371,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "tokio-runtime")]
     async fn unsized_data() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
 
         let addr = "pulsar://127.0.0.1:6650";
         let test_id: u16 = rand::random();
@@ -457,8 +457,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "tokio-runtime")]
     async fn redelivery() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
 
         let addr = "pulsar://127.0.0.1:6650";
         let topic = format!("test_redelivery_{}", rand::random::<u16>());
@@ -503,8 +503,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "tokio-runtime")]
     async fn batching() {
-        let _ = log::set_logger(&TEST_LOGGER);
-        let _ = log::set_max_level(LevelFilter::Debug);
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
 
         let addr = "pulsar://127.0.0.1:6650";
         let topic = format!("test_batching_{}", rand::random::<u16>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@
 //!     Ok(())
 //! }
 //! ```
+#![recursion_limit = "256"]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::large_enum_variant)]
 extern crate futures;

--- a/src/message.rs
+++ b/src/message.rs
@@ -527,22 +527,22 @@ impl BatchedMessage {
     }
 }
 
-#[rustfmt::skip]
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/pulsar.proto.rs"));
 
     //trait implementations used in Consumer::unacked_messages
     impl std::cmp::Eq for MessageIdData {}
 
+    #[allow(clippy::derive_hash_xor_eq)]
     impl std::hash::Hash for MessageIdData {
-         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-             self.ledger_id.hash(state);
-             self.entry_id.hash(state);
-             self.partition.hash(state);
-             self.batch_index.hash(state);
-             self.ack_set.hash(state);
-             self.batch_size.hash(state);
-         }
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.ledger_id.hash(state);
+            self.entry_id.hash(state);
+            self.partition.hash(state);
+            self.batch_index.hash(state);
+            self.ack_set.hash(state);
+            self.batch_size.hash(state);
+        }
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -33,6 +33,7 @@ pub struct Message {
 
 impl Message {
     /// returns the message's RequestKey if present
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn request_key(&self) -> Option<RequestKey> {
         match &self.command {
             BaseCommand {
@@ -222,6 +223,7 @@ pub struct Codec;
 impl tokio_util::codec::Encoder<Message> for Codec {
     type Error = ConnectionError;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), ConnectionError> {
         let command_size = item.command.encoded_len();
         let metadata_size = item
@@ -271,6 +273,7 @@ impl tokio_util::codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Message>, ConnectionError> {
         trace!("Decoder received {} bytes", src.len());
         if src.len() >= 4 {
@@ -326,6 +329,7 @@ impl asynchronous_codec::Encoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), ConnectionError> {
         let command_size = item.command.encoded_len();
         let metadata_size = item
@@ -375,6 +379,7 @@ impl asynchronous_codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Message>, ConnectionError> {
         trace!("Decoder received {} bytes", src.len());
         if src.len() >= 4 {
@@ -442,6 +447,7 @@ struct CommandFrame<'a> {
     command: &'a [u8],
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn command_frame(i: &[u8]) -> IResult<&[u8], CommandFrame> {
     let (i, total_size) = be_u32(i)?;
     let (i, command_size) = be_u32(i)?;
@@ -467,6 +473,7 @@ struct PayloadFrame<'a> {
     metadata: &'a [u8],
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn payload_frame(i: &[u8]) -> IResult<&[u8], PayloadFrame> {
     let (i, magic_number) = be_u16(i)?;
     let (i, checksum) = be_u32(i)?;
@@ -489,6 +496,7 @@ pub(crate) struct BatchedMessage {
     pub payload: Vec<u8>,
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn batched_message(i: &[u8]) -> IResult<&[u8], BatchedMessage> {
     let (i, metadata_size) = be_u32(i)?;
     let (i, metadata) = verify(
@@ -508,6 +516,7 @@ fn batched_message(i: &[u8]) -> IResult<&[u8], BatchedMessage> {
     ))
 }
 
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 pub(crate) fn parse_batched_message(
     count: u32,
     payload: &[u8],
@@ -520,6 +529,7 @@ pub(crate) fn parse_batched_message(
 }
 
 impl BatchedMessage {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) fn serialize(&self, w: &mut Vec<u8>) {
         w.put_u32(self.metadata.encoded_len() as u32);
         let _ = self.metadata.encode(w);
@@ -535,6 +545,7 @@ pub mod proto {
 
     #[allow(clippy::derive_hash_xor_eq)]
     impl std::hash::Hash for MessageIdData {
+        #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
             self.ledger_id.hash(state);
             self.entry_id.hash(state);
@@ -549,6 +560,7 @@ pub mod proto {
 impl TryFrom<i32> for proto::base_command::Type {
     type Error = ();
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn try_from(value: i32) -> Result<Self, ()> {
         match value {
             2 => Ok(proto::base_command::Type::Connect),
@@ -591,12 +603,14 @@ impl TryFrom<i32> for proto::base_command::Type {
 }
 
 impl From<prost::EncodeError> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(e: prost::EncodeError) -> Self {
         ConnectionError::Encoding(e.to_string())
     }
 }
 
 impl From<prost::DecodeError> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(e: prost::DecodeError) -> Self {
         ConnectionError::Decoding(e.to_string())
     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -475,7 +475,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     {
                         error!("create_producer({}) answered ServiceNotReady, retrying request after {}ms (max_retries = {:?}): {}",
                         topic, operation_retry_options.retry_delay.as_millis(),
-                        operation_retry_options.max_retries, text.unwrap_or_else(String::new));
+                        operation_retry_options.max_retries, text.unwrap_or_default());
 
                         current_retries += 1;
                         client
@@ -503,7 +503,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     {
                         error!("create_producer({}) answered ProducerBusy, retrying request after {}ms (max_retries = {:?}): {}",
                         topic, operation_retry_options.retry_delay.as_millis(),
-                        operation_retry_options.max_retries, text.unwrap_or_else(String::new));
+                        operation_retry_options.max_retries, text.unwrap_or_default());
 
                         current_retries += 1;
                         client
@@ -529,31 +529,29 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     if e.kind() != std::io::ErrorKind::TimedOut {
                         warn!("send_inner got io error: {:?}", e);
                         return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
-                    } else {
-                        if operation_retry_options.max_retries.is_none()
-                            || operation_retry_options.max_retries.unwrap() > current_retries
-                        {
-                            error!(
+                    } else if operation_retry_options.max_retries.is_none()
+                        || operation_retry_options.max_retries.unwrap() > current_retries
+                    {
+                        error!(
                                 "create_producer({}) TimedOut, retrying request after {}ms (max_retries = {:?})",
                                 topic, operation_retry_options.retry_delay.as_millis(),
                                 operation_retry_options.max_retries
                             );
 
-                            current_retries += 1;
-                            client
-                                .executor
-                                .delay(operation_retry_options.retry_delay)
-                                .await;
+                        current_retries += 1;
+                        client
+                            .executor
+                            .delay(operation_retry_options.retry_delay)
+                            .await;
 
-                            let addr = client.lookup_topic(&topic).await?;
-                            connection = client.manager.get_connection(&addr).await?;
+                        let addr = client.lookup_topic(&topic).await?;
+                        connection = client.manager.get_connection(&addr).await?;
 
-                            continue;
-                        } else {
-                            error!("create_producer({}) reached max retries", topic);
+                        continue;
+                    } else {
+                        error!("create_producer({}) reached max retries", topic);
 
-                            return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
-                        }
+                        return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
                     }
                 }
                 //this also captures producer fenced error
@@ -885,7 +883,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     {
                         warn!("create_producer({}) answered ServiceNotReady, retrying request after {}ms (max_retries = {:?}): {}",
                         topic, operation_retry_options.retry_delay.as_millis(),
-                        operation_retry_options.max_retries, text.unwrap_or_else(String::new));
+                        operation_retry_options.max_retries, text.unwrap_or_default());
 
                         current_retries += 1;
                         self.client
@@ -922,7 +920,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     {
                         warn!("create_producer({}) answered ProducerBusy, retrying request after {}ms (max_retries = {:?}): {}",
                         topic, operation_retry_options.retry_delay.as_millis(),
-                        operation_retry_options.max_retries, text.unwrap_or_else(String::new));
+                        operation_retry_options.max_retries, text.unwrap_or_default());
 
                         current_retries += 1;
                         self.client
@@ -957,23 +955,22 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     if e.kind() != std::io::ErrorKind::TimedOut {
                         error!("send_inner got io error: {:?}", e);
                         return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
-                    } else {
-                        if operation_retry_options.max_retries.is_none()
-                            || operation_retry_options.max_retries.unwrap() > current_retries
-                        {
-                            warn!("create_producer({}) TimedOut, retrying request after {}ms (max_retries = {:?})",
+                    } else if operation_retry_options.max_retries.is_none()
+                        || operation_retry_options.max_retries.unwrap() > current_retries
+                    {
+                        warn!("create_producer({}) TimedOut, retrying request after {}ms (max_retries = {:?})",
                             topic, operation_retry_options.retry_delay.as_millis(), operation_retry_options.max_retries);
 
-                            current_retries += 1;
-                            self.client
-                                .executor
-                                .delay(operation_retry_options.retry_delay)
-                                .await;
+                        current_retries += 1;
+                        self.client
+                            .executor
+                            .delay(operation_retry_options.retry_delay)
+                            .await;
 
-                            let addr = self.client.lookup_topic(&topic).await?;
-                            self.connection = self.client.manager.get_connection(&addr).await?;
+                        let addr = self.client.lookup_topic(&topic).await?;
+                        self.connection = self.client.manager.get_connection(&addr).await?;
 
-                            warn!(
+                        warn!(
                             "Retry #{} -> reconnecting producer {:#} using connection {:#} to broker {:#} to topic {:#}",
                             current_retries,
                             self.id,
@@ -982,11 +979,10 @@ impl<Exe: Executor> TopicProducer<Exe> {
                             self.topic
                         );
 
-                            continue;
-                        } else {
-                            error!("create_producer({}) reached max retries", topic);
-                            return Err(Error::Connection(ConnectionError::Io(e)));
-                        }
+                        continue;
+                    } else {
+                        error!("create_producer({}) reached max retries", topic);
+                        return Err(Error::Connection(ConnectionError::Io(e)));
                     }
                 }
                 Err(e) => {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -29,6 +29,7 @@ pub struct SendFuture(pub(crate) oneshot::Receiver<Result<CommandSendReceipt, Er
 impl Future for SendFuture {
     type Output = Result<CommandSendReceipt, Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.0).poll(cx) {
             Poll::Ready(Ok(r)) => Poll::Ready(r),
@@ -99,6 +100,7 @@ pub(crate) struct ProducerMessage {
 }
 
 impl From<Message> for ProducerMessage {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(m: Message) -> Self {
         ProducerMessage {
             payload: m.payload,
@@ -158,16 +160,19 @@ pub struct MultiTopicProducer<Exe: Executor> {
 
 impl<Exe: Executor> MultiTopicProducer<Exe> {
     /// producer options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn options(&self) -> &ProducerOptions {
         &self.options
     }
 
     /// list topics currently handled by this producer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn topics(&self) -> Vec<String> {
         self.producers.keys().cloned().collect()
     }
 
     /// stops the producer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn close_producer<S: Into<String>>(&mut self, topic: S) -> Result<(), Error> {
         let partitions = self.client.lookup_partitioned_topic(topic).await?;
         for (topic, _) in partitions {
@@ -177,6 +182,7 @@ impl<Exe: Executor> MultiTopicProducer<Exe> {
     }
 
     /// sends one message on a topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send<T: SerializeMessage + Sized, S: Into<String>>(
         &mut self,
         topic: S,
@@ -202,6 +208,7 @@ impl<Exe: Executor> MultiTopicProducer<Exe> {
     }
 
     /// sends a list of messages on a topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send_all<'a, 'b, T, S, I>(
         &mut self,
         topic: S,
@@ -235,11 +242,13 @@ pub struct Producer<Exe: Executor> {
 
 impl<Exe: Executor> Producer<Exe> {
     /// creates a producer builder from a client instance
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn builder(pulsar: &Pulsar<Exe>) -> ProducerBuilder<Exe> {
         ProducerBuilder::new(pulsar)
     }
 
     /// this producer's topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn topic(&self) -> &str {
         match &self.inner {
             ProducerInner::Single(p) => p.topic(),
@@ -248,6 +257,7 @@ impl<Exe: Executor> Producer<Exe> {
     }
 
     /// list of partitions for this producer's topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn partitions(&self) -> Option<Vec<String>> {
         match &self.inner {
             ProducerInner::Single(_) => None,
@@ -258,6 +268,7 @@ impl<Exe: Executor> Producer<Exe> {
     }
 
     /// configuration options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn options(&self) -> &ProducerOptions {
         match &self.inner {
             ProducerInner::Single(p) => p.options(),
@@ -268,11 +279,13 @@ impl<Exe: Executor> Producer<Exe> {
     /// creates a message builder
     ///
     /// the created message will ber sent by this producer in [MessageBuilder::send]
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn create_message(&mut self) -> MessageBuilder<(), Exe> {
         MessageBuilder::new(self)
     }
 
     /// test that the broker connections are still valid
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn check_connection(&self) -> Result<(), Error> {
         match &self.inner {
             ProducerInner::Single(p) => p.check_connection().await,
@@ -303,6 +316,7 @@ impl<Exe: Executor> Producer<Exe> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send<T: SerializeMessage + Sized>(
         &mut self,
         message: T,
@@ -314,6 +328,7 @@ impl<Exe: Executor> Producer<Exe> {
     }
 
     /// sends a list of messages
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send_all<T, I>(&mut self, messages: I) -> Result<Vec<SendFuture>, Error>
     where
         T: SerializeMessage,
@@ -335,6 +350,7 @@ impl<Exe: Executor> Producer<Exe> {
     }
 
     /// sends the current batch of messages
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send_batch(&mut self) -> Result<(), Error> {
         match &mut self.inner {
             ProducerInner::Single(p) => p.send_batch().await,
@@ -346,6 +362,7 @@ impl<Exe: Executor> Producer<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn send_raw(&mut self, message: ProducerMessage) -> Result<SendFuture, Error> {
         match &mut self.inner {
             ProducerInner::Single(p) => p.send_raw(message).await,
@@ -367,6 +384,7 @@ struct PartitionedProducer<Exe: Executor> {
 }
 
 impl<Exe: Executor> PartitionedProducer<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn next(&mut self) -> &mut TopicProducer<Exe> {
         self.producers.rotate_left(1);
         self.producers.front_mut().unwrap()
@@ -390,6 +408,7 @@ struct TopicProducer<Exe: Executor> {
 }
 
 impl<Exe: Executor> TopicProducer<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn from_connection<S: Into<String>>(
         client: Pulsar<Exe>,
         mut connection: Arc<Connection<Exe>>,
@@ -582,19 +601,23 @@ impl<Exe: Executor> TopicProducer<Exe> {
         })
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn topic(&self) -> &str {
         &self.topic
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn options(&self) -> &ProducerOptions {
         &self.options
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn check_connection(&self) -> Result<(), Error> {
         self.connection.sender().send_ping().await?;
         Ok(())
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send<T: SerializeMessage + Sized>(&mut self, message: T) -> Result<SendFuture, Error> {
         match T::serialize_message(message) {
             Ok(message) => self.send_raw(message.into()).await,
@@ -602,6 +625,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_batch(&mut self) -> Result<(), Error> {
         match self.batch.as_ref() {
             None => Err(ProducerError::Custom("not a batching producer".to_string()).into()),
@@ -645,6 +669,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub(crate) async fn send_raw(&mut self, message: ProducerMessage) -> Result<SendFuture, Error> {
         let (tx, rx) = oneshot::channel();
         match self.batch.as_ref() {
@@ -695,6 +720,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_compress(
         &mut self,
         mut message: ProducerMessage,
@@ -782,6 +808,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         self.send_inner(compressed_message).await
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn send_inner(
         &mut self,
         message: ProducerMessage,
@@ -817,6 +844,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn reconnect(&mut self) -> Result<(), Error> {
         debug!("reconnecting producer for topic: {}", self.topic);
         // Sender::send() method consumes the sender
@@ -1023,6 +1051,7 @@ pub struct ProducerBuilder<Exe: Executor> {
 
 impl<Exe: Executor> ProducerBuilder<Exe> {
     /// creates a new ProducerBuilder from a client
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new(pulsar: &Pulsar<Exe>) -> Self {
         ProducerBuilder {
             pulsar: pulsar.clone(),
@@ -1033,24 +1062,28 @@ impl<Exe: Executor> ProducerBuilder<Exe> {
     }
 
     /// sets the producer's topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic<S: Into<String>>(mut self, topic: S) -> Self {
         self.topic = Some(topic.into());
         self
     }
 
     /// sets the producer's name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_name<S: Into<String>>(mut self, name: S) -> Self {
         self.name = Some(name.into());
         self
     }
 
     /// configuration options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_options(mut self, options: ProducerOptions) -> Self {
         self.producer_options = Some(options);
         self
     }
 
     /// creates a new producer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn build(self) -> Result<Producer<Exe>, Error> {
         let ProducerBuilder {
             pulsar,
@@ -1105,6 +1138,7 @@ impl<Exe: Executor> ProducerBuilder<Exe> {
     }
 
     /// creates a new [MultiTopicProducer]
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn build_multi_topic(self) -> MultiTopicProducer<Exe> {
         MultiTopicProducer {
             client: self.pulsar,
@@ -1129,6 +1163,7 @@ struct Batch {
 }
 
 impl Batch {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new(length: u32) -> Batch {
         Batch {
             length,
@@ -1136,10 +1171,12 @@ impl Batch {
         }
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn is_full(&self) -> bool {
         self.storage.lock().await.len() >= self.length as usize
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn push_back(
         &self,
         msg: (
@@ -1169,6 +1206,7 @@ impl Batch {
         self.storage.lock().await.push_back((tx, batched))
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_messages(
         &self,
     ) -> Vec<(
@@ -1194,6 +1232,7 @@ pub struct MessageBuilder<'a, T, Exe: Executor> {
 
 impl<'a, Exe: Executor> MessageBuilder<'a, (), Exe> {
     /// creates a message builder from an existing producer
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn new(producer: &'a mut Producer<Exe>) -> Self {
         MessageBuilder {
             producer,
@@ -1209,6 +1248,7 @@ impl<'a, Exe: Executor> MessageBuilder<'a, (), Exe> {
 
 impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     /// sets the message's content
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_content<C>(self, content: C) -> MessageBuilder<'a, C, Exe> {
         MessageBuilder {
             producer: self.producer,
@@ -1222,11 +1262,14 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     }
 
     /// sets the message's partition key
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_partition_key<S: Into<String>>(mut self, partition_key: S) -> Self {
         self.partition_key = Some(partition_key.into());
         self
     }
+
     /// sets the message's ordering key for key_shared subscription
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_ordering_key<S: Into<String>>(mut self, partition_key: S) -> Self {
         self.partition_key = Some(partition_key.into());
         self
@@ -1236,24 +1279,28 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     ///
     /// this is the same as `with_partition_key`, this method is added for
     /// more consistency with other clients
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_key<S: Into<String>>(mut self, partition_key: S) -> Self {
         self.partition_key = Some(partition_key.into());
         self
     }
 
     /// sets a user defined property
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_property<S1: Into<String>, S2: Into<String>>(mut self, key: S1, value: S2) -> Self {
         self.properties.insert(key.into(), value.into());
         self
     }
 
     /// delivers the message at this date
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn deliver_at(mut self, date: SystemTime) -> Result<Self, std::time::SystemTimeError> {
         self.deliver_at_time = Some(date.duration_since(UNIX_EPOCH)?.as_millis() as i64);
         Ok(self)
     }
 
     /// delays message deliver with this duration
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn delay(mut self, delay: Duration) -> Result<Self, std::time::SystemTimeError> {
         let date = SystemTime::now() + delay;
         println!(
@@ -1266,6 +1313,7 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     }
 
     /// delivers the message at this date
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn event_time(mut self, event_time: u64) -> Self {
         self.event_time = Some(event_time);
         self
@@ -1274,6 +1322,7 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
 
 impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> {
     /// sends the message through the producer that created it
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn send(self) -> Result<SendFuture, Error> {
         let MessageBuilder {
             producer,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -29,6 +29,7 @@ pub enum State<T: DeserializeMessage> {
 impl<T: DeserializeMessage + 'static, Exe: Executor> Stream for Reader<T, Exe> {
     type Item = Result<Message<T>, Error>;
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         match this.state.take().unwrap() {
@@ -88,54 +89,67 @@ impl<T: DeserializeMessage, Exe: Executor> Reader<T, Exe> {
     */
 
     /// test that the connections to the Pulsar brokers are still valid
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn check_connection(&mut self) -> Result<(), Error> {
         self.consumer.check_connection().await
     }
 
     /// returns topic this reader is subscribed on
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn topic(&self) -> String {
         self.consumer.topic()
     }
 
     /// returns a list of broker URLs this reader is connected to
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn connections(&mut self) -> Result<Url, Error> {
         Ok(self.consumer.connection().await?.url().clone())
     }
+
     /// returns the consumer's configuration options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn options(&self) -> &ConsumerOptions {
         &self.consumer.config.options
     }
 
     // is this necessary?
     /// returns the consumer's dead letter policy options
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn dead_letter_policy(&self) -> Option<&DeadLetterPolicy> {
         self.consumer.dead_letter_policy.as_ref()
     }
 
     /// returns the readers's subscription name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn subscription(&self) -> &str {
         &self.consumer.config.subscription
     }
+
     /// returns the reader's subscription type
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn sub_type(&self) -> SubType {
         self.consumer.config.sub_type
     }
 
     /// returns the reader's batch size
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn batch_size(&self) -> Option<u32> {
         self.consumer.config.batch_size
     }
 
     /// returns the reader's name
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn reader_name(&self) -> Option<&str> {
         self.consumer.config.consumer_name.as_deref()
     }
 
     /// returns the reader's id
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn reader_id(&self) -> u64 {
         self.consumer.consumer_id
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn seek(
         &mut self,
         message_id: Option<MessageIdData>,
@@ -145,15 +159,18 @@ impl<T: DeserializeMessage, Exe: Executor> Reader<T, Exe> {
     }
 
     /// returns the date of the last message reception
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn last_message_received(&self) -> Option<DateTime<Utc>> {
         self.consumer.last_message_received()
     }
 
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_last_message_id(&mut self) -> Result<MessageIdData, Error> {
         self.consumer.get_last_message_id().await
     }
 
     /// returns the current number of messages received
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn messages_received(&self) -> u64 {
         self.consumer.messages_received()
     }

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -20,11 +20,13 @@ pub struct ServiceDiscovery<Exe: Executor> {
 }
 
 impl<Exe: Executor> ServiceDiscovery<Exe> {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_manager(manager: Arc<ConnectionManager<Exe>>) -> Self {
         ServiceDiscovery { manager }
     }
 
     /// get the broker address for a topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_topic<S: Into<String>>(
         &self,
         topic: S,
@@ -164,6 +166,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
     }
 
     /// get the number of partitions for a partitioned topic
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_partitioned_topic_number<S: Into<String>>(
         &self,
         topic: S,
@@ -242,6 +245,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
 
     /// Lookup a topic, returning a list of the partitions (if partitioned) and addresses
     /// associated with that topic.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn lookup_partitioned_topic<S: Into<String>>(
         &self,
         topic: S,
@@ -275,6 +279,7 @@ struct LookupResponse {
 }
 
 /// extracts information from a lookup response
+#[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn convert_lookup_response(
     response: &CommandLookupTopicResponse,
 ) -> Result<LookupResponse, ServiceDiscoveryError> {


### PR DESCRIPTION
Hello :wave:, 

To find an issue on production, I needed more observability of the software that use this crate, to get more insights, I put tracing annotation on functions behind a compiler feature flag to not add change to the current behavior of the driver.

Besides, I saw that the driver needed some love. So, I have updated all dependencies using the same way to write the semantic version using `^x.x.x` which allow to lock easily a version, if something does not work as expected in future version of a crate through this syntax `=x.x.x`. I also have updated the Rust edition which is now the latest one `2021`, which asked at least Rust `1.56.0`, if my memory is good.

Last thing, I have set the right version number of the crate on the `Cargo.toml` according to the latest git tag.

Have a wonderful day!
