### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ keywords = ["pulsar", "api", "client"]
 [dependencies]
 bytes = "^1.2.1"
 crc = "^3.0.0"
-futures = "^0.3.24"
 nom = { version="^7.1.1", default-features=false, features=["alloc"] }
 prost = "^0.11.0"
 prost-derive = "^0.11.0"
@@ -29,7 +28,8 @@ log = "^0.4.17"
 url = "^2.3.1"
 regex = "^1.6.0"
 bit-vec = "^0.6.3"
-futures-io = "^0.3.24"
+futures = "^0.3.25"
+futures-io = "^0.3.25"
 native-tls = "^0.2.10"
 pem = "^1.1.0"
 tokio = { version = "^1.21.2", features = ["rt", "net", "time"], optional = true }
@@ -42,14 +42,14 @@ lz4 = { version = "^1.24.0", optional = true }
 flate2 = { version = "^1.0.24", optional = true }
 zstd = { version = "^0.11.2", optional = true }
 snap = { version = "^1.0.5", optional = true }
-openidconnect = { version = "^2.3.2", optional = true }
+openidconnect = { version = "^2.4.0", optional = true }
 oauth2 = { version = "^4.2.3", optional = true }
-serde = { version = "^1.0.145", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.85", optional = true }
-tracing = { version = "^0.1.36", optional = true }
-async-trait = "^0.1.57"
+serde = { version = "^1.0.147", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.87", optional = true }
+tracing = { version = "^0.1.37", optional = true }
+async-trait = "^0.1.58"
 data-url = { version = "^0.2.0", optional = true }
-uuid = {version = "^1.1.2", features = ["v4", "fast-rng"] }
+uuid = {version = "^1.2.1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 serde = { version = "^1.0.145", features = ["derive"] }


### PR DESCRIPTION
* Bump futures to 0.3.25
* Bump futures-io to 0.3.25
* Bump openidconnect to 2.4.0
* Bump serde to 1.0.147
* Bump serde_json to 1.0.87
* Bump tracing to 0.1.37
* Bump async-trait to 0.1.58
* Bump uuid to 1.2.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>