### PR TITLE
Add the ability to `ack`, `nack` and `cumulative_ack` by message ID.

### DIFF
--- a/src/consumer/data.rs
+++ b/src/consumer/data.rs
@@ -16,8 +16,8 @@ pub enum EngineEvent<Exe: Executor> {
 }
 
 pub enum EngineMessage<Exe: Executor> {
-    Ack(MessageData, bool),
-    Nack(MessageData),
+    Ack(MessageIdData, bool),
+    Nack(MessageIdData),
     UnackedRedelivery,
     GetConnection(oneshot::Sender<Arc<Connection<Exe>>>),
 }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -117,12 +117,30 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
         }
     }
 
+    /// acknowledges a single message with a given ID.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        match &mut self.inner {
+            InnerConsumer::Single(c) => c.ack_with_id(msg_id).await,
+            InnerConsumer::Multi(c) => c.ack_with_id(topic, msg_id).await,
+        }
+    }
+
     /// acknowledges a message and all the preceding messages
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.cumulative_ack(msg).await,
             InnerConsumer::Multi(c) => c.cumulative_ack(msg).await,
+        }
+    }
+
+    /// acknowledges a message and all the preceding messages with a given ID.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn cumulative_ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        match &mut self.inner {
+            InnerConsumer::Single(c) => c.cumulative_ack_with_id(msg_id).await,
+            InnerConsumer::Multi(c) => c.cumulative_ack_with_id(topic, msg_id).await,
         }
     }
 
@@ -134,6 +152,17 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.nack(msg).await,
             InnerConsumer::Multi(c) => c.nack(msg).await,
+        }
+    }
+
+    /// negative acknowledgement
+    ///
+    /// the message with the given ID will be sent again on the subscription
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn nack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        match &mut self.inner {
+            InnerConsumer::Single(c) => c.nack_with_id(msg_id).await,
+            InnerConsumer::Multi(c) => c.nack_with_id(topic, msg_id).await,
         }
     }
 

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -119,7 +119,11 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
 
     /// acknowledges a single message with a given ID.
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn ack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.ack_with_id(msg_id).await,
             InnerConsumer::Multi(c) => c.ack_with_id(topic, msg_id).await,
@@ -137,7 +141,11 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
 
     /// acknowledges a message and all the preceding messages with a given ID.
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn cumulative_ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn cumulative_ack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.cumulative_ack_with_id(msg_id).await,
             InnerConsumer::Multi(c) => c.cumulative_ack_with_id(topic, msg_id).await,
@@ -159,7 +167,11 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     ///
     /// the message with the given ID will be sent again on the subscription
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn nack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn nack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.nack_with_id(msg_id).await,
             InnerConsumer::Multi(c) => c.nack_with_id(topic, msg_id).await,

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -208,11 +208,29 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        if let Some(c) = self.consumers.get_mut(topic) {
+            c.ack_with_id(msg_id).await
+        } else {
+            Err(ConnectionError::Unexpected(format!("no consumer for topic {}", topic)).into())
+        }
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(&msg.topic) {
             c.cumulative_ack(msg).await
         } else {
             Err(ConnectionError::Unexpected(format!("no consumer for topic {}", msg.topic)).into())
+        }
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn cumulative_ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        if let Some(c) = self.consumers.get_mut(topic) {
+            c.cumulative_ack_with_id(msg_id).await
+        } else {
+            Err(ConnectionError::Unexpected(format!("no consumer for topic {}", topic)).into())
         }
     }
 
@@ -223,6 +241,16 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             Ok(())
         } else {
             Err(ConnectionError::Unexpected(format!("no consumer for topic {}", msg.topic)).into())
+        }
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn nack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        if let Some(c) = self.consumers.get_mut(topic) {
+            c.nack_with_id(msg_id).await?;
+            Ok(())
+        } else {
+            Err(ConnectionError::Unexpected(format!("no consumer for topic {}", topic)).into())
         }
     }
 

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -208,7 +208,11 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn ack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(topic) {
             c.ack_with_id(msg_id).await
         } else {
@@ -226,7 +230,11 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn cumulative_ack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn cumulative_ack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(topic) {
             c.cumulative_ack_with_id(msg_id).await
         } else {
@@ -245,7 +253,11 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn nack_with_id(&mut self, topic: &str, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn nack_with_id(
+        &mut self,
+        topic: &str,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         if let Some(c) = self.consumers.get_mut(topic) {
             c.nack_with_id(msg_id).await?;
             Ok(())

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -344,7 +344,10 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub async fn cumulative_ack_with_id(&mut self, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+    pub async fn cumulative_ack_with_id(
+        &mut self,
+        msg_id: MessageIdData,
+    ) -> Result<(), ConsumerError> {
         self.engine_tx
             .send(EngineMessage::Ack(msg_id, true))
             .await?;
@@ -361,9 +364,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn nack_with_id(&mut self, msg_id: MessageIdData) -> Result<(), ConsumerError> {
-        self.engine_tx
-            .send(EngineMessage::Nack(msg_id))
-            .await?;
+        self.engine_tx.send(EngineMessage::Nack(msg_id)).await?;
         Ok(())
     }
 

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -317,7 +317,15 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
-            .send(EngineMessage::Ack(msg.message_id.clone(), false))
+            .send(EngineMessage::Ack(msg.message_id().clone(), false))
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn ack_with_id(&mut self, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        self.engine_tx
+            .send(EngineMessage::Ack(msg_id, false))
             .await?;
         Ok(())
     }
@@ -330,7 +338,15 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
-            .send(EngineMessage::Ack(msg.message_id.clone(), true))
+            .send(EngineMessage::Ack(msg.message_id().clone(), true))
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn cumulative_ack_with_id(&mut self, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        self.engine_tx
+            .send(EngineMessage::Ack(msg_id, true))
             .await?;
         Ok(())
     }
@@ -338,7 +354,15 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn nack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         self.engine_tx
-            .send(EngineMessage::Nack(msg.message_id.clone()))
+            .send(EngineMessage::Nack(msg.message_id().clone()))
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub async fn nack_with_id(&mut self, msg_id: MessageIdData) -> Result<(), ConsumerError> {
+        self.engine_tx
+            .send(EngineMessage::Nack(msg_id))
             .await?;
         Ok(())
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -52,7 +52,7 @@ impl<T: DeserializeMessage + 'static, Exe: Executor> Stream for Reader<T, Exe> {
 
                 Poll::Ready(Some(Ok(msg))) => {
                     let mut acker = this.consumer.acker();
-                    let message_id = msg.message_id.clone();
+                    let message_id = msg.message_id().clone();
                     this.state = Some(State::PollingAck(
                         msg,
                         Box::pin(


### PR DESCRIPTION
This PR adds the ability to `ack`, `nack` and `cumulative_ack` by message ID and topic name.

This is done because in some situations (like the one we have in Quickwit) we don't want to keep the original messages around or can't in some cases, instead using only the required metadata of the topic name and message-id data.