### PR TITLE
Add support for on-the-fly AuthChallenge

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1049,6 +1049,7 @@ impl<Exe: Executor> Connection<Exe> {
 
         if auth.is_some() {
             let auth_challenge_res = executor.spawn({
+                let err = error.clone();
                 let mut tx = tx.clone();
                 let auth = auth.clone();
                 Box::pin(async move {
@@ -1058,7 +1059,8 @@ impl<Exe: Executor> Connection<Exe> {
                                 let _ = tx.send(messages::auth_challenge(auth_data)).await;
                             }
                             Ok(None) => (),
-                            _ => {
+                            Err(e) => {
+                                err.set(e);
                                 break;
                             }
                         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1565,14 +1565,8 @@ pub(crate) mod messages {
 
 #[cfg(test)]
 mod tests {
-    use super::{Connection, Receiver};
-    use crate::{
-        authentication::Authentication,
-        error::{AuthenticationError, SharedError},
-        message::{BaseCommand, Codec, Message},
-        proto::{CommandAuthChallenge, CommandConnected},
-        TokioExecutor,
-    };
+    use std::{sync::Arc, time::Duration};
+
     use async_trait::async_trait;
     use futures::{
         channel::{mpsc, oneshot},
@@ -1580,10 +1574,17 @@ mod tests {
         stream::StreamExt,
         SinkExt,
     };
-    use std::{sync::Arc, time::Duration};
     use tokio::{net::TcpListener, sync::RwLock};
     use uuid::Uuid;
-    use crate::proto::{AuthData, CommandAuthResponse};
+
+    use super::{Connection, Receiver};
+    use crate::{
+        authentication::Authentication,
+        error::{AuthenticationError, SharedError},
+        message::{BaseCommand, Codec, Message},
+        proto::{AuthData, CommandAuthChallenge, CommandAuthResponse, CommandConnected},
+        TokioExecutor,
+    };
 
     #[tokio::test]
     #[cfg(feature = "tokio-runtime")]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1691,8 +1691,6 @@ mod tests {
             .await
             .unwrap();
 
-        server_stream.flush().await.unwrap();
-
         let connection = Connection::connect(
             Uuid::new_v4(),
             stream,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1705,9 +1705,6 @@ mod tests {
         )
         .await;
 
-        // We need to sleep to allow time for the messages to be processed
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
         let _ = server_stream.next().await;
         let auth_challenge = server_stream.next().await.unwrap();
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1568,23 +1568,23 @@ pub(crate) mod messages {
 
 #[cfg(test)]
 mod tests {
-
     use super::{Connection, Receiver};
-    use crate::authentication::Authentication;
-    use crate::error::{AuthenticationError, SharedError};
-    use crate::message::{BaseCommand, Codec, Message};
-    use crate::proto::{CommandAuthChallenge, CommandConnected};
-    use crate::TokioExecutor;
+    use crate::{
+        authentication::Authentication,
+        error::{AuthenticationError, SharedError},
+        message::{BaseCommand, Codec, Message},
+        proto::{CommandAuthChallenge, CommandConnected},
+        TokioExecutor,
+    };
     use async_trait::async_trait;
-    use futures::channel::mpsc;
-    use futures::channel::oneshot;
-    use futures::lock::Mutex;
-    use futures::stream::StreamExt;
-    use futures::SinkExt;
-    use std::sync::Arc;
-    use std::time::Duration;
-    use tokio::net::TcpListener;
-    use tokio::sync::RwLock;
+    use futures::{
+        channel::{mpsc, oneshot},
+        lock::Mutex,
+        stream::StreamExt,
+        SinkExt,
+    };
+    use std::{sync::Arc, time::Duration};
+    use tokio::{net::TcpListener, sync::RwLock};
     use uuid::Uuid;
 
     #[tokio::test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -185,6 +185,10 @@ impl Message {
                 request_id: *request_id,
             }),
             BaseCommand {
+                auth_challenge: Some(CommandAuthChallenge { .. }),
+                ..
+            } => Some(RequestKey::AuthChallenge),
+            BaseCommand {
                 connect: Some(_), ..
             }
             | BaseCommand {
@@ -597,6 +601,8 @@ impl TryFrom<i32> for base_command::Type {
             33 => Ok(base_command::Type::GetTopicsOfNamespaceResponse),
             34 => Ok(base_command::Type::GetSchema),
             35 => Ok(base_command::Type::GetSchemaResponse),
+            36 => Ok(base_command::Type::AuthChallenge),
+            37 => Ok(base_command::Type::AuthResponse),
             _ => Err(()),
         }
     }
@@ -686,6 +692,6 @@ mod tests {
                 assert_eq!(type_ as i32, i);
             }
         }
-        assert_eq!(successes, 34);
+        assert_eq!(successes, 36);
     }
 }


### PR DESCRIPTION
This PR Adds support for on-the-fly auth by handling the `AuthChallengeRequest` command.

Currently receiving `AuthChallengeRequest` logs an error and drops the command; this behaviour can lead to the client becoming disconnected. Instead, the client should authenticate with the Auth provider again and send an `AuthChallengeResponse` command containing the new `auth_data`, which will keep the connection alive.