### PR TITLE
Use atomic long to gen producer/consumer ids and simplify debugging

### DIFF
--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -29,7 +29,7 @@ use crate::{
     BrokerAddress, DeserializeMessage, Error, Executor, Payload, Pulsar,
 };
 
-static consumer_id_generator: AtomicU64 = AtomicU64::new(0);
+static CONSUMER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
 
 // this is entirely public for use in reader.rs
 pub struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
@@ -63,7 +63,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             options,
             dead_letter_policy,
         } = config.clone();
-        let consumer_id = consumer_id.unwrap_or_else(consumer_id_generator.fetch_add(1, Ordering::SeqCst));
+        let consumer_id = consumer_id.unwrap_or_else(|| CONSUMER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst));
         let (resolver, messages) = mpsc::unbounded();
         let batch_size = batch_size.unwrap_or(1000);
 

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -2,8 +2,10 @@ use std::{
     io::ErrorKind,
     marker::PhantomData,
     pin::Pin,
-    sync::Arc,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -29,8 +31,6 @@ use crate::{
     BrokerAddress, DeserializeMessage, Error, Executor, Payload, Pulsar,
 };
 
-static CONSUMER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
-
 // this is entirely public for use in reader.rs
 pub struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
     pub(crate) consumer_id: u64,
@@ -53,6 +53,8 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         mut addr: BrokerAddress,
         config: ConsumerConfig,
     ) -> Result<TopicConsumer<T, Exe>, Error> {
+        static CONSUMER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
+
         let ConsumerConfig {
             subscription,
             sub_type,
@@ -63,7 +65,8 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             options,
             dead_letter_policy,
         } = config.clone();
-        let consumer_id = consumer_id.unwrap_or_else(|| CONSUMER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst));
+        let consumer_id =
+            consumer_id.unwrap_or_else(|| CONSUMER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst));
         let (resolver, messages) = mpsc::unbounded();
         let batch_size = batch_size.unwrap_or(1000);
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -543,7 +543,7 @@ pub mod proto {
     //trait implementations used in Consumer::unacked_messages
     impl Eq for MessageIdData {}
 
-    #[allow(clippy::derive_hash_xor_eq)]
+    #[allow(clippy::derived_hash_with_manual_eq)]
     impl std::hash::Hash for MessageIdData {
         #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -4,6 +4,7 @@ use std::{
     io::Write,
     pin::Pin,
     sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -30,6 +31,8 @@ use crate::{
 
 type ProducerId = u64;
 type ProducerName = String;
+
+static producer_id_generator: AtomicU64 = AtomicU64::new(0);
 
 /// returned by [Producer::send]
 ///
@@ -439,7 +442,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         options: ProducerOptions,
     ) -> Result<Self, Error> {
         let topic = topic.into();
-        let producer_id = rand::random();
+        let producer_id = producer_id_generator.fetch_add(1, Ordering::SeqCst);
         let sequence_ids = SerialId::new();
 
         let topic = topic.clone();

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -3,8 +3,10 @@ use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     io::Write,
     pin::Pin,
-    sync::Arc,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -31,8 +33,6 @@ use crate::{
 
 type ProducerId = u64;
 type ProducerName = String;
-
-static PRODUCER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
 
 /// returned by [Producer::send]
 ///
@@ -441,6 +441,8 @@ impl<Exe: Executor> TopicProducer<Exe> {
         name: Option<String>,
         options: ProducerOptions,
     ) -> Result<Self, Error> {
+        static PRODUCER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
+
         let topic = topic.into();
         let producer_id = PRODUCER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst);
         let sequence_ids = SerialId::new();

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -32,7 +32,7 @@ use crate::{
 type ProducerId = u64;
 type ProducerName = String;
 
-static producer_id_generator: AtomicU64 = AtomicU64::new(0);
+static PRODUCER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
 
 /// returned by [Producer::send]
 ///
@@ -442,7 +442,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
         options: ProducerOptions,
     ) -> Result<Self, Error> {
         let topic = topic.into();
-        let producer_id = producer_id_generator.fetch_add(1, Ordering::SeqCst);
+        let producer_id = PRODUCER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst);
         let sequence_ids = SerialId::new();
 
         let topic = topic.clone();


### PR DESCRIPTION
Fixes: #265 

The issue has all of the context. The general idea is to improve debugging given that Java is mapping an unsigned long to a signed long and then logging that value.

I am still learning rust, so if any of my usage is incorrect, please correct it!