### PR TITLE
Fix ConsumerEngine::reconnect loop

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1130,7 +1130,7 @@ impl<Exe: Executor> Connection<Exe> {
 impl<Exe: Executor> Drop for Connection<Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn drop(&mut self) {
-        trace!("dropping connection {} for {}", self.id, self.url);
+        debug!("dropping connection {} for {}", self.id, self.url);
         if let Some(shutdown) = self.sender.receiver_shutdown.take() {
             let _ = shutdown.send(());
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -46,6 +46,9 @@ pub(crate) enum Register {
         consumer_id: u64,
         resolver: mpsc::UnboundedSender<Message>,
     },
+    RemoveConsumer {
+        consumer_id: u64,
+    },
     Ping {
         resolver: oneshot::Sender<()>,
     },
@@ -156,6 +159,9 @@ impl<S: Stream<Item = Result<Message, ConnectionError>>> Future for Receiver<S> 
                     resolver,
                 })) => {
                     self.consumers.insert(consumer_id, resolver);
+                }
+                Poll::Ready(Some(Register::RemoveConsumer { consumer_id })) => {
+                    self.consumers.remove(&consumer_id);
                 }
                 Poll::Ready(Some(Register::Ping { resolver })) => {
                     self.ping = Some(resolver);
@@ -549,6 +555,16 @@ impl<Exe: Executor> ConnectionSender<Exe> {
     ) -> Result<proto::CommandSuccess, ConnectionError> {
         let request_id = self.request_id.get();
         let msg = messages::close_consumer(consumer_id, request_id);
+        match self
+            .registrations
+            .unbounded_send(Register::RemoveConsumer { consumer_id })
+        {
+            Ok(_) => {}
+            Err(_) => {
+                self.error.set(ConnectionError::Disconnected);
+                return Err(ConnectionError::Disconnected);
+            }
+        }
         self.send_message(msg, RequestKey::RequestId(request_id), |resp| {
             resp.command.success
         })

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -448,7 +448,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 }
             }
             Some(ConnectionStatus::Connected(_)) => {
-                //info!("removing old connection");
+                info!("removing old connection");
             }
             None => {
                 //info!("setting up new connection");

--- a/src/consumer/initial_position.rs
+++ b/src/consumer/initial_position.rs
@@ -1,17 +1,11 @@
 /// position of the first message that will be consumed
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub enum InitialPosition {
     /// start at the oldest message
     Earliest,
     /// start at the most recent message
+    #[default]
     Latest,
-}
-
-impl Default for InitialPosition {
-    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    fn default() -> Self {
-        InitialPosition::Latest
-    }
 }
 
 impl From<InitialPosition> for i32 {

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -1,5 +1,4 @@
 use std::{
-    io::ErrorKind,
     marker::PhantomData,
     pin::Pin,
     sync::{
@@ -7,7 +6,7 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use chrono::{DateTime, Utc};
@@ -26,8 +25,8 @@ use crate::{
     },
     error::{ConnectionError, ConsumerError},
     message::proto::MessageIdData,
-    proto,
     proto::CommandConsumerStatsResponse,
+    retry_op::retry_subscribe_consumer,
     BrokerAddress, DeserializeMessage, Error, Executor, Payload, Pulsar,
 };
 
@@ -38,7 +37,6 @@ pub struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
     topic: String,
     messages: Pin<Box<MessageIdDataReceiver>>,
     engine_tx: mpsc::UnboundedSender<EngineMessage<Exe>>,
-    #[allow(unused)]
     data_type: PhantomData<fn(Payload) -> T::Output>,
     pub(crate) dead_letter_policy: Option<DeadLetterPolicy>,
     pub(super) last_message_received: Option<DateTime<Utc>>,
@@ -50,7 +48,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     pub(super) async fn new(
         client: Pulsar<Exe>,
         topic: String,
-        mut addr: BrokerAddress,
+        addr: BrokerAddress,
         config: ConsumerConfig,
     ) -> Result<TopicConsumer<T, Exe>, Error> {
         static CONSUMER_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
@@ -67,142 +65,22 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         } = config.clone();
         let consumer_id =
             consumer_id.unwrap_or_else(|| CONSUMER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst));
-        let (resolver, messages) = mpsc::unbounded();
         let batch_size = batch_size.unwrap_or(1000);
-
         let mut connection = client.manager.get_connection(&addr).await?;
-        let mut current_retries = 0u32;
-        let start = Instant::now();
-        let operation_retry_options = client.operation_retry_options.clone();
 
-        loop {
-            match connection
-                .sender()
-                .subscribe(
-                    resolver.clone(),
-                    topic.clone(),
-                    subscription.clone(),
-                    sub_type,
-                    consumer_id,
-                    consumer_name.clone(),
-                    options.clone(),
-                )
-                .await
-            {
-                Ok(_) => {
-                    if current_retries > 0 {
-                        let dur = (Instant::now() - start).as_secs();
-                        log::info!(
-                            "subscribe({}) success after {} retries over {} seconds",
-                            topic,
-                            current_retries + 1,
-                            dur
-                        );
-                    }
-                    break;
-                }
-                Err(ConnectionError::PulsarError(Some(err), text))
-                    if matches!(
-                        err,
-                        proto::ServerError::ServiceNotReady | proto::ServerError::ConsumerBusy
-                    ) =>
-                {
-                    // Pulsar retryable error
-                    match operation_retry_options.max_retries {
-                        Some(max_retries) if current_retries < max_retries => {
-                            error!("subscribe({}) answered {}, retrying request after {}ms (max_retries = {:?}): {}",
-                                topic, err.as_str_name(), operation_retry_options.retry_delay.as_millis(),
-                                operation_retry_options.max_retries, text.unwrap_or_default());
-
-                            current_retries += 1;
-                            client
-                                .executor
-                                .delay(operation_retry_options.retry_delay)
-                                .await;
-
-                            // we need to look up again the topic's address
-                            let prev = addr;
-                            addr = client.lookup_topic(&topic).await?;
-                            if prev != addr {
-                                info!(
-                                    "topic {} moved: previous = {:?}, new = {:?}",
-                                    topic, prev, addr
-                                );
-                            }
-
-                            connection = client.manager.get_connection(&addr).await?;
-                            continue;
-                        }
-                        _ => {
-                            error!("subscribe({}) reached max retries", topic);
-
-                            return Err(ConnectionError::PulsarError(
-                                Some(proto::ServerError::ServiceNotReady),
-                                text,
-                            )
-                            .into());
-                        }
-                    }
-                }
-                Err(ConnectionError::Io(e))
-                    if matches!(
-                        e.kind(),
-                        ErrorKind::ConnectionReset
-                            | ErrorKind::ConnectionAborted
-                            | ErrorKind::NotConnected
-                            | ErrorKind::BrokenPipe
-                            | ErrorKind::TimedOut
-                            | ErrorKind::Interrupted
-                            | ErrorKind::UnexpectedEof
-                    ) =>
-                {
-                    match operation_retry_options.max_retries {
-                        Some(max_retries) if current_retries < max_retries => {
-                            error!(
-                                    "create consumer( {} {}, retrying request after {}ms (max_retries = {:?})",
-                                    topic, e.kind().to_string(), operation_retry_options.retry_delay.as_millis(),
-                                    operation_retry_options.max_retries
-                                );
-
-                            current_retries += 1;
-                            client
-                                .executor
-                                .delay(operation_retry_options.retry_delay)
-                                .await;
-
-                            let prev = addr.clone();
-                            let addr = client.lookup_topic(&topic).await?;
-
-                            if prev != addr {
-                                info!(
-                                    "topic {} moved: previous = {:?}, new = {:?}",
-                                    topic, prev, addr
-                                );
-                            }
-
-                            connection = client.manager.get_connection(&addr).await?;
-
-                            continue;
-                        }
-                        _ => {
-                            // The error was retryable but the number of overall retries
-                            // is exhausted
-                            return Err(ConsumerError::Io(e).into());
-                        }
-                    }
-                }
-                Err(e) => return Err(Error::Connection(e)),
-            }
-        }
-
-        connection
-            .sender()
-            .send_flow(consumer_id, batch_size)
-            .map_err(|e| {
-                error!("TopicConsumer::new error[{}]: {:?}", line!(), e);
-                e
-            })
-            .map_err(|e| Error::Consumer(ConsumerError::Connection(e)))?;
+        let messages = retry_subscribe_consumer(
+            &client,
+            &mut connection,
+            addr,
+            &topic,
+            &subscription,
+            sub_type,
+            consumer_id,
+            &consumer_name,
+            &options,
+            batch_size,
+        )
+        .await?;
 
         let (engine_tx, engine_rx) = mpsc::unbounded();
 
@@ -242,13 +120,14 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             dead_letter_policy.clone(),
             options.clone(),
         );
-        if client.executor.spawn(Box::pin(async move {
+        let engine_task = client.executor.spawn(Box::pin(async move {
             c.engine()
                 .map(|res| {
                     debug!("consumer engine stopped: {:?}", res);
                 })
                 .await;
-        })).is_err() {
+        }));
+        if engine_task.is_err() {
             return Err(Error::Executor);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ pub mod executor;
 pub mod message;
 pub mod producer;
 pub mod reader;
+mod retry_op;
 mod service_discovery;
 
 #[cfg(test)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -543,7 +543,6 @@ pub mod proto {
     //trait implementations used in Consumer::unacked_messages
     impl Eq for MessageIdData {}
 
-    #[allow(clippy::derived_hash_with_manual_eq)]
     impl std::hash::Hash for MessageIdData {
         #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/src/retry_op.rs
+++ b/src/retry_op.rs
@@ -1,0 +1,219 @@
+use std::{io::ErrorKind, sync::Arc, time::Instant};
+
+use futures::channel::mpsc::{self, UnboundedReceiver};
+
+use crate::{
+    connection::Connection,
+    error::{ConnectionError, ConsumerError},
+    message::Message,
+    proto, BrokerAddress, ConsumerOptions, Error, Executor, ProducerOptions, Pulsar, SubType,
+};
+
+pub async fn handle_retry_error<Exe: Executor>(
+    client: &Pulsar<Exe>,
+    connection: &mut Arc<Connection<Exe>>,
+    addr: &mut BrokerAddress,
+    topic: &str,
+    operation_name: &str,
+    current_retries: u32,
+    err: ConnectionError,
+) -> Result<(), Error> {
+    let operation_retry_options = &client.operation_retry_options;
+    let (kind, text) = match err {
+        ConnectionError::PulsarError(Some(kind), ref text)
+            if matches!(
+                kind,
+                proto::ServerError::ServiceNotReady
+                    | proto::ServerError::ConsumerBusy
+                    | proto::ServerError::ProducerBusy
+            ) =>
+        {
+            (
+                kind.as_str_name().to_owned(),
+                text.as_ref()
+                    .map(|text| format!(" (\"{text}\")"))
+                    .unwrap_or_default(),
+            )
+        }
+        ConnectionError::Io(ref kind)
+            if matches!(
+                kind.kind(),
+                ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::NotConnected
+                    | ErrorKind::BrokenPipe
+                    | ErrorKind::TimedOut
+                    | ErrorKind::Interrupted
+                    | ErrorKind::UnexpectedEof
+            ) =>
+        {
+            (kind.kind().to_string(), "".to_owned())
+        }
+        err => {
+            error!("{operation_name}({topic}) error: {err:?}");
+            return Err(err.into());
+        }
+    };
+    match operation_retry_options.max_retries {
+        Some(max_retries) if current_retries < max_retries => {
+            error!(
+                "{operation_name}({topic}) answered {kind}{text}, retrying request after {:?} (max_retries = {max_retries})",
+                operation_retry_options.retry_delay
+            );
+            client
+                .executor
+                .delay(operation_retry_options.retry_delay)
+                .await;
+
+            *addr = client.lookup_topic(topic).await?;
+            *connection = client.manager.get_connection(addr).await?;
+            Ok(())
+        }
+        _ => {
+            error!("{operation_name}({topic}) answered {kind}{text}, reached max retries");
+            Err(err.into())
+        }
+    }
+}
+
+pub async fn retry_subscribe_consumer<Exe: Executor>(
+    client: &Pulsar<Exe>,
+    connection: &mut Arc<Connection<Exe>>,
+    mut addr: BrokerAddress,
+    topic: &str,
+    subscription: &str,
+    sub_type: SubType,
+    consumer_id: u64,
+    consumer_name: &Option<String>,
+    options: &ConsumerOptions,
+    batch_size: u32,
+) -> Result<UnboundedReceiver<Message>, Error> {
+    *connection = client.manager.get_connection(&addr).await?;
+    let (resolver, messages) = mpsc::unbounded();
+    let mut current_retries = 0u32;
+    let start = Instant::now();
+
+    loop {
+        warn!(
+            "Retry #{current_retries} -> connecting consumer {consumer_id} using connection {:#} to broker {:#} to topic {topic}",
+            connection.id(),
+            addr.url,
+        );
+        match connection
+            .sender()
+            .subscribe(
+                resolver.clone(),
+                topic.to_owned(),
+                subscription.to_owned(),
+                sub_type,
+                consumer_id,
+                consumer_name.clone(),
+                options.clone(),
+            )
+            .await
+        {
+            Ok(_) => {
+                if current_retries > 0 {
+                    let dur = (Instant::now() - start).as_secs();
+                    info!(
+                        "TopicConsumer::subscribe({topic}) success after {} retries over {dur} seconds",
+                        current_retries + 1,
+                    );
+                }
+                break;
+            }
+            Err(err) => {
+                handle_retry_error(
+                    client,
+                    connection,
+                    &mut addr,
+                    topic,
+                    "TopicConsumer::subscribe",
+                    current_retries,
+                    err,
+                )
+                .await?
+            }
+        }
+        current_retries += 1;
+    }
+    connection
+        .sender()
+        .send_flow(consumer_id, batch_size)
+        .map_err(|err| {
+            error!("TopicConsumer::send_flow({topic}) error: {err:?}");
+            Error::Consumer(ConsumerError::Connection(err))
+        })?;
+
+    Ok(messages)
+}
+
+pub async fn retry_create_producer<Exe: Executor>(
+    client: &Pulsar<Exe>,
+    connection: &mut Arc<Connection<Exe>>,
+    mut addr: BrokerAddress,
+    topic: &String,
+    producer_id: u64,
+    producer_name: Option<String>,
+    options: &ProducerOptions,
+) -> Result<String, Error> {
+    *connection = client.manager.get_connection(&addr).await?;
+    let mut current_retries = 0u32;
+    let start = Instant::now();
+
+    loop {
+        warn!(
+            "Retry #{current_retries} -> connecting producer {producer_id} using connection {:#} to broker {:#} to topic {topic}",
+            connection.id(),
+            addr.url,
+        );
+        match connection
+            .sender()
+            .create_producer(
+                topic.clone(),
+                producer_id,
+                producer_name.clone(),
+                options.clone(),
+            )
+            .await
+        {
+            Ok(partial_success) => {
+                // If producer is not "ready", the client will avoid to timeout the request
+                // for creating the producer. Instead it will wait indefinitely until it gets
+                // a subsequent  `CommandProducerSuccess` with `producer_ready==true`.
+                if let Some(producer_ready) = partial_success.producer_ready {
+                    if !producer_ready {
+                        // wait until next commandproducersuccess message has been received
+                        trace!("TopicProducer::create({topic}) waiting for exclusive access");
+                        let result = connection
+                            .sender()
+                            .wait_for_exclusive_access(partial_success.request_id)
+                            .await;
+                        trace!("TopicProducer::create({topic}) received: {result:?}");
+                    }
+                }
+                if current_retries > 0 {
+                    let dur = (std::time::Instant::now() - start).as_secs();
+                    log::info!(
+                        "TopicProducer::create({topic}) success after {} retries over {dur} seconds",
+                        current_retries + 1,
+                    );
+                }
+                return Ok(partial_success.producer_name);
+            }
+            Err(err) => {
+                handle_retry_error(
+                    client,
+                    connection,
+                    &mut addr,
+                    topic,
+                    "TopicProducer::create",
+                    current_retries,
+                    err,
+                )
+                .await?
+            }
+        }
+        current_retries += 1;
+    }
+}


### PR DESCRIPTION
This patch is to fix #263.

The first commit contains the main fix, which should be sufficient to reconnect a consumer correctly. The two fixes are, as discussed in the issue :
- ignore the drop of the old message source
- send the flow message over the new connection

The following commits aim to clean up some related parts of the connection and reconnection code, to make it clearer and hopefully less error-prone.