### PR TITLE
Remove un-subscription when closing consumer

### DIFF
--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -254,7 +254,6 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    /// Unsubscribe the topic then close the connection
     pub async fn close(&mut self) -> Result<(), Error> {
         match &mut self.inner {
             InnerConsumer::Single(c) => c.close().await,

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -262,7 +262,6 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn close(&mut self) -> Result<(), Error> {
         let consumer_id = self.consumer_id;
-        self.unsubscribe().await?;
         self.connection()
             .await?
             .sender()


### PR DESCRIPTION
Remove 'unsubscribe' from `consumer.close()`

https://github.com/streamnative/pulsar-rs/issues/279