### PR TITLE
chore: Implement Sync for Consumer

### DIFF
--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -30,9 +30,10 @@ pub struct MultiTopicConsumer<T: DeserializeMessage, Exe: Executor> {
     pub(super) topics: VecDeque<String>,
     pub(super) existing_topics: VecDeque<String>,
     #[allow(clippy::type_complexity)]
-    pub(super) new_consumers:
-        Option<Pin<Box<dyn Future<Output = Result<Vec<TopicConsumer<T, Exe>>, Error>> + Send>>>,
-    pub(super) refresh: Pin<Box<dyn Stream<Item = ()> + Send>>,
+    pub(super) new_consumers: Option<
+        Pin<Box<dyn Future<Output = Result<Vec<TopicConsumer<T, Exe>>, Error>> + Send + Sync>>,
+    >,
+    pub(super) refresh: Pin<Box<dyn Stream<Item = ()> + Send + Sync>>,
     pub(super) config: ConsumerConfig,
     // Stats on disconnected consumers to keep metrics correct
     pub(super) disc_messages_received: u64,

--- a/src/error.rs
+++ b/src/error.rs
@@ -406,7 +406,7 @@ impl std::error::Error for ServiceDiscoveryError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum AuthenticationError {
     Custom(String),
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -252,7 +252,7 @@ pub enum Delay {
     Tokio(tokio::time::Sleep),
     /// wrapper around async-std's `Delay`
     #[cfg(any(feature = "async-std-runtime", features = "async-std-rustls-runtime"))]
-    AsyncStd(Pin<Box<dyn Future<Output = ()> + Send>>),
+    AsyncStd(Pin<Box<dyn Future<Output = ()> + Send + Sync>>),
 }
 
 impl Future for Delay {


### PR DESCRIPTION
Hi! This request adds the auto implementation of `Sync` for `Consumer`.

Currently, `Sync` is not implemented for `Consumer`, which causes error when trying to move the consumer to a backgound task. See the code below as an example.

```
async main() {
    let consumer: Consumer<TestData, _> = pulsar
        .consumer()
        .build()
        .await?;

    let mut app = App { consumer };

    tokio::task::spawn(app.run()).await.unwrap();
}

struct App {
    consumer: Consumer<TestData, TokioExecutor>,
}

impl App {
    async fn run(&mut self) {
        while let Some(_msg) = self.consumer.try_next().await.unwrap() {
            self.dosomething().await;
        }
    }

    async fn dosomething(&self) {}
}
```

---
- Updated the example.
