### PR TITLE
fix: do not auto redirect to tls scheme

### DIFF
--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -117,7 +117,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
             is_authoritative = authoritative;
 
             // Use broker url with the same schema of manager.url
-            let (connection_url, broker_url) = match self.manager.url.scheme() {
+            let (connection_url, broker_url) = match base_url.scheme() {
                 "pulsar+ssl" => {
                     if let Some(u) = &broker_url_tls {
                         (


### PR DESCRIPTION
This patch fix the problem that the client will
auto redirect to tls scheme even setting non-tls broker url which may confuse the user.