### PR TITLE
fix: end client rx upon disconnection error

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -103,6 +103,9 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 let r = event_tx.send(mapper(Some(msg))).await;
                 if let Err(err) = r {
                     log::error!("Error sending event to channel - {err}");
+                    if err.is_disconnected() {
+                        break;
+                    }
                 }
             }
             let send_end_res = event_tx.send(mapper(None)).await;


### PR DESCRIPTION
Currently, consumers can enter an infinite error logging loop when Pulsar goes down (even if it goes back up).

The cause seems to be that, when registering an event source, the send loop never exits, even if the event sink is disconnected. This patch fixes it.