### PR TITLE
temp disable clippy deprecated error

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1075,6 +1075,7 @@ impl<Exe: Executor> Connection<Exe> {
                 feature = "async-std-rustls-runtime",
                 not(feature = "async-std-runtime")
             ))]
+            #[allow(deprecated)]
             ExecutorKind::AsyncStd => {
                 if tls {
                     let stream = async_std::net::TcpStream::connect(&address).await?;


### PR DESCRIPTION
fix error
```
error: use of deprecated struct `async_rustls::TlsConnector`: This crate is now deprecated in favor of [futures-rustls](https://crates.io/crates/futures-rustls).
    --> src/connection.rs:1108:51
     |
1108 |                     let connector = async_rustls::TlsConnector::from(Arc::new(config));
     |                                                   ^^^^^^^^^^^^
     |
     = note: `-D deprecated` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(deprecated)]`

error: use of deprecated method `async_rustls::TlsConnector::connect`: This crate is now deprecated in favor of [futures-rustls](https://crates.io/crates/futures-rustls).
    --> src/connection.rs:1110:26
     |
1110 |                         .connect(rustls::ServerName::try_from(hostname.as_str())?, stream)
     |                          ^^^^^^^

```