### PR TITLE
Revert "feat: Change send to not block on waiting receipt (#298)"

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -538,7 +538,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                 };
 
                 trace!("sending a batched message of size {}", message_count);
-                let send_receipt = self.send_compress(message).await?.await.map_err(Arc::new);
+                let send_receipt = self.send_compress(message).await.map_err(Arc::new);
                 for resolver in receipts {
                     let _ = resolver.send(
                         send_receipt
@@ -557,13 +557,8 @@ impl<Exe: Executor> TopicProducer<Exe> {
         let (tx, rx) = oneshot::channel();
         match self.batch.as_ref() {
             None => {
-                let fut = self.send_compress(message).await?;
-                self.client
-                    .executor
-                    .spawn(Box::pin(async move {
-                        let _ = tx.send(fut.await);
-                    }))
-                    .map_err(|_| Error::Executor)?;
+                let receipt = self.send_compress(message).await?;
+                let _ = tx.send(Ok(receipt));
                 Ok(SendFuture(rx))
             }
             Some(batch) => {
@@ -591,18 +586,16 @@ impl<Exe: Executor> TopicProducer<Exe> {
                         ..Default::default()
                     };
 
+                    let send_receipt = self.send_compress(message).await.map_err(Arc::new);
+
                     trace!("sending a batched message of size {}", counter);
-                    let receipt_fut = self.send_compress(message).await?;
-                    self.client
-                        .executor
-                        .spawn(Box::pin(async move {
-                            let res = receipt_fut.await.map_err(Arc::new);
-                            for tx in receipts.drain(..) {
-                                let _ = tx
-                                    .send(res.clone().map_err(|e| ProducerError::Batch(e).into()));
-                            }
-                        }))
-                        .map_err(|_| Error::Executor)?;
+                    for tx in receipts.drain(..) {
+                        let _ = tx.send(
+                            send_receipt
+                                .clone()
+                                .map_err(|e| ProducerError::Batch(e).into()),
+                        );
+                    }
                 }
 
                 Ok(SendFuture(rx))
@@ -614,7 +607,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
     async fn send_compress(
         &mut self,
         mut message: ProducerMessage,
-    ) -> Result<impl Future<Output = Result<CommandSendReceipt, Error>>, Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         let compressed_message = match self.compression.clone() {
             None | Some(Compression::None) => message,
             #[cfg(feature = "lz4")]
@@ -681,25 +674,16 @@ impl<Exe: Executor> TopicProducer<Exe> {
     async fn send_inner(
         &mut self,
         message: ProducerMessage,
-    ) -> Result<impl Future<Output = Result<CommandSendReceipt, Error>>, Error> {
+    ) -> Result<proto::CommandSendReceipt, Error> {
         loop {
             let msg = message.clone();
-            match self.connection.sender().send(
-                self.id,
-                self.name.clone(),
-                self.message_id.get(),
-                msg,
-            ) {
-                Ok(fut) => {
-                    let fut = async move {
-                        let res = fut.await;
-                        res.map_err(|e| {
-                            error!("wait send receipt got error: {:?}", e);
-                            Error::Producer(ProducerError::Connection(e))
-                        })
-                    };
-                    return Ok(fut);
-                }
+            match self
+                .connection
+                .sender()
+                .send(self.id, self.name.clone(), self.message_id.get(), msg)
+                .await
+            {
+                Ok(receipt) => return Ok(receipt),
                 Err(ConnectionError::Disconnected) => {}
                 Err(ConnectionError::Io(e)) => {
                     if e.kind() != std::io::ErrorKind::TimedOut {


### PR DESCRIPTION
This reverts commit 5c245cd3c720bc364c71d98e7e2c782429e5c7a9.


### Motivation

Pr #298 made a change to the sending process so that we don't need to wait for the receipt to send the next message.  that's a good idea to improve the performance. but I have to revert it because it is a breaking change for existing users. suppose they were using it without a rate limiter for large messages. it will let many messages stuck in the Tokio task queue and some tasks get timed.