### PR TITLE
feat: Replace unbounded channel with bounded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ description = "Rust client for Apache Pulsar"
 keywords = ["pulsar", "api", "client"]
 
 [dependencies]
+async-channel = "2"
 bytes = "^1.4.0"
 crc = "^3.0.1"
 nom = { version="^7.1.3", default-features=false, features=["alloc"] }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -123,6 +123,7 @@ pub struct ConnectionManager<Exe: Executor> {
     pub(crate) operation_retry_options: OperationRetryOptions,
     tls_options: TlsOptions,
     certificate_chain: Vec<Certificate>,
+    outbound_channel_size: usize,
 }
 
 impl<Exe: Executor> ConnectionManager<Exe> {
@@ -133,6 +134,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
         connection_retry: Option<ConnectionRetryOptions>,
         operation_retry_options: OperationRetryOptions,
         tls: Option<TlsOptions>,
+        outbound_channel_size: usize,
         executor: Arc<Exe>,
     ) -> Result<Self, ConnectionError> {
         let connection_retry_options = connection_retry.unwrap_or_default();
@@ -191,6 +193,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
             operation_retry_options,
             tls_options,
             certificate_chain,
+            outbound_channel_size,
         };
         let broker_address = BrokerAddress {
             url: url.clone(),
@@ -312,6 +315,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                 self.tls_options.tls_hostname_verification_enabled,
                 self.connection_retry_options.connection_timeout,
                 self.operation_retry_options.operation_timeout,
+                self.outbound_channel_size,
                 self.executor.clone(),
             )
             .await

--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -159,6 +159,11 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                             .sender()
                             .send_flow(self.id, self.batch_size - self.remaining_messages)?;
                     }
+                    Err(ConnectionError::SlowDown) => {
+                        self.connection
+                            .sender()
+                            .send_flow(self.id, self.batch_size - self.remaining_messages)?;
+                    }
                     Err(e) => return Err(e.into()),
                 }
                 self.remaining_messages = self.batch_size;


### PR DESCRIPTION
This is the follow-up of https://github.com/streamnative/pulsar-rs/pull/311 and https://github.com/streamnative/pulsar-rs/pull/310

1. Use a bounded channel for the outbound message queue. This size of the channel can be configured with method `with_outbount_channel_size` of the client builder.
2. A new ConnectionError `SlowDown` is introduced. This error is returned when the internal message queue for sending is full.