### PR TITLE
bump prost and prost-build to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ async-channel = "2"
 bytes = "^1.4.0"
 crc = "^3.0.1"
 nom = { version="^7.1.3", default-features=false, features=["alloc"] }
-prost = "^0.11.9"
-prost-derive = "^0.11.9"
+prost = "^0.13.1"
+prost-derive = "^0.13.1"
 rand = "^0.8.5"
 chrono = { version = "^0.4.26", default-features = false, features = ["clock", "std"] }
 futures-timer = "^3.0.2"
@@ -63,7 +63,7 @@ env_logger = "^0.10.0"
 tokio = { version = "^1.29.1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-prost-build = "^0.11.9"
+prost-build = "^0.13.1"
 protobuf-src = { version = "1.1.0", optional = true }
 
 [features]


### PR DESCRIPTION
To avoid conflicts in software that make use of both pulsar-rs and protobuf version 0.13.1