### PR TITLE
fix: Block the sending of control messages

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -351,7 +351,7 @@ impl<Exe: Executor> ConnectionSender<Exe> {
         match (
             self.registrations
                 .unbounded_send(Register::Ping { resolver }),
-            self.tx.try_send(messages::ping())?,
+            self.tx.send(messages::ping()).await?,
         ) {
             (Ok(_), ()) => {
                 let delay_f = self.executor.delay(self.operation_timeout);
@@ -526,35 +526,42 @@ impl<Exe: Executor> ConnectionSender<Exe> {
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub fn send_flow(&self, consumer_id: u64, message_permits: u32) -> Result<(), ConnectionError> {
+    pub async fn send_flow(
+        &self,
+        consumer_id: u64,
+        message_permits: u32,
+    ) -> Result<(), ConnectionError> {
         self.tx
-            .try_send(messages::flow(consumer_id, message_permits))?;
+            .send(messages::flow(consumer_id, message_permits))
+            .await?;
         Ok(())
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub fn send_ack(
+    pub async fn send_ack(
         &self,
         consumer_id: u64,
         message_ids: Vec<proto::MessageIdData>,
         cumulative: bool,
     ) -> Result<(), ConnectionError> {
         self.tx
-            .try_send(messages::ack(consumer_id, message_ids, cumulative))?;
+            .send(messages::ack(consumer_id, message_ids, cumulative))
+            .await?;
         Ok(())
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub fn send_redeliver_unacknowleged_messages(
+    pub async fn send_redeliver_unacknowleged_messages(
         &self,
         consumer_id: u64,
         message_ids: Vec<proto::MessageIdData>,
     ) -> Result<(), ConnectionError> {
         self.tx
-            .try_send(messages::redeliver_unacknowleged_messages(
+            .send(messages::redeliver_unacknowleged_messages(
                 consumer_id,
                 message_ids,
-            ))?;
+            ))
+            .await?;
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,13 @@ impl From<AuthenticationError> for ConnectionError {
     }
 }
 
+impl<T> From<async_channel::SendError<T>> for ConnectionError {
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    fn from(_err: async_channel::SendError<T>) -> Self {
+        ConnectionError::Disconnected
+    }
+}
+
 impl<T> From<async_channel::TrySendError<T>> for ConnectionError {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: async_channel::TrySendError<T>) -> Self {

--- a/src/retry_op.rs
+++ b/src/retry_op.rs
@@ -140,6 +140,7 @@ pub async fn retry_subscribe_consumer<Exe: Executor>(
     connection
         .sender()
         .send_flow(consumer_id, batch_size)
+        .await
         .map_err(|err| {
             error!("TopicConsumer::send_flow({topic}) error: {err:?}");
             Error::Consumer(ConsumerError::Connection(err))


### PR DESCRIPTION
Block and wait on the channel to be not full for sending the control messages. This is for fixing https://github.com/streamnative/pulsar-rs/issues/317