### PR TITLE
chore: update dependencies and use send_non_blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,63 +16,63 @@ description = "Rust client for Apache Pulsar"
 keywords = ["pulsar", "api", "client"]
 
 [dependencies]
-async-channel = "2"
-bytes = "^1.4.0"
-crc = "^3.0.1"
-nom = { version="^7.1.3", default-features=false, features=["alloc"] }
+async-channel = "^2.3.1"
+async-trait = "^0.1.81"
+async-std = { version = "^1.12.0", features = ["attributes", "unstable"], optional = true }
+async-native-tls = { version = "^0.5.0", optional = true }
+asynchronous-codec = { version = "^0.7.0", optional = true }
+bytes = "^1.6.1"
+bit-vec = "^0.8.0"
+chrono = { version = "^0.4.38", default-features = false, features = ["clock", "std"] }
+crc = "^3.2.1"
+data-url = { version = "^0.3.1", optional = true }
+flate2 = { version = "^1.0.30", optional = true }
+futures = "^0.3.30"
+futures-io = "^0.3.30"
+futures-timer = "^3.0.3"
+futures-rustls = { version = "^0.26.0", optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
+log = "^0.4.22"
+lz4 = { version = "^1.26.0", optional = true }
+native-tls = { version = "^0.2.12", optional = true }
+nom = { version = "^7.1.3", default-features = false, features = ["alloc"] }
+openidconnect = { version = "^3.5.0", optional = true }
+oauth2 = { version = "^4.4.1", optional = true }
+pem = "^3.0.4"
 prost = "^0.13.1"
 prost-derive = "^0.13.1"
 rand = "^0.8.5"
-chrono = { version = "^0.4.26", default-features = false, features = ["clock", "std"] }
-futures-timer = "^3.0.2"
-log = "^0.4.19"
-url = "^2.4.0"
-regex = "^1.9.1"
-bit-vec = "^0.6.3"
-futures = "^0.3.28"
-futures-io = "^0.3.28"
-native-tls = { version = "^0.2.11", optional = true }
-rustls = { version = "^0.21.6", optional = true }
-webpki-roots = { version = "^0.25.1", optional = true }
-pem = "^3.0.0"
-tokio = { version = "^1.29.1", features = ["rt", "net", "time"], optional = true }
-tokio-util = { version = "^0.7.8", features = ["codec"], optional = true }
-tokio-rustls = { version = "^0.24.1", optional = true }
+regex = "^1.10.5"
+rustls = { version = "^0.23.12", optional = true }
+snap = { version = "^1.1.1", optional = true }
+serde = { version = "^1.0.204", features = ["derive"], optional = true }
+serde_json = { version = "^1.0.121", optional = true }
+tokio = { version = "^1.39.2", features = ["rt", "net", "time"], optional = true }
+tokio-util = { version = "^0.7.11", features = ["codec"], optional = true }
+tokio-rustls = { version = "^0.26.0", optional = true }
 tokio-native-tls = { version = "^0.3.1", optional = true }
-async-std = { version = "^1.12.0", features = [ "attributes", "unstable" ], optional = true }
-asynchronous-codec = { version = "^0.6.2", optional = true }
-async-rustls = { version = "^0.4.0", optional = true }
-async-native-tls = { version = "^0.5.0", optional = true }
-lz4 = { version = "^1.24.0", optional = true }
-flate2 = { version = "^1.0.26", optional = true }
-zstd = { version = "^0.12.4", optional = true }
-snap = { version = "^1.1.0", optional = true }
-openidconnect = { version = "^3.3.0", optional = true }
-oauth2 = { version = "^4.4.1", optional = true }
-serde = { version = "^1.0.175", features = ["derive"], optional = true }
-serde_json = { version = "^1.0.103", optional = true }
-tracing = { version = "^0.1.37", optional = true }
-async-trait = "^0.1.72"
-data-url = { version = "^0.3.0", optional = true }
-uuid = { version = "^1.4.1", features = ["v4", "fast-rng"] }
+tracing = { version = "^0.1.40", optional = true }
+url = "^2.5.2"
+uuid = { version = "^1.10.0", features = ["v4", "fast-rng"] }
+webpki-roots = { version = "^0.26.3", optional = true }
+zstd = { version = "^0.13.2", optional = true }
 
 [dev-dependencies]
-serde = { version = "^1.0.175", features = ["derive"] }
-serde_json = "^1.0.103"
-env_logger = "^0.10.0"
-tokio = { version = "^1.29.1", features = ["macros", "rt-multi-thread"] }
+env_logger = "^0.11.5"
+serde = { version = "^1.0.204", features = ["derive"] }
+serde_json = "^1.0.121"
+tokio = { version = "^1.39.2", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 prost-build = "^0.13.1"
-protobuf-src = { version = "1.1.0", optional = true }
+protobuf-src = { version = "^2.1.0", optional = true }
 
 [features]
-default = [ "compression", "tokio-runtime", "async-std-runtime", "auth-oauth2" ]
-compression = [ "lz4", "flate2", "zstd", "snap" ]
-tokio-runtime = [ "tokio", "tokio-util", "native-tls", "tokio-native-tls" ]
-tokio-rustls-runtime = ["tokio", "tokio-util", "tokio-rustls", "rustls", "webpki-roots" ]
-async-std-runtime = [ "async-std", "asynchronous-codec", "native-tls", "async-native-tls" ]
-async-std-rustls-runtime = ["async-std", "asynchronous-codec", "async-rustls", "rustls", "webpki-roots" ]
-auth-oauth2 = [ "openidconnect", "oauth2", "serde", "serde_json", "data-url" ]
-telemetry = ["tracing"]
+async-std-runtime = ["async-std", "asynchronous-codec", "native-tls", "async-native-tls"]
+async-std-rustls-runtime = ["async-std", "asynchronous-codec", "futures-rustls", "rustls", "webpki-roots"]
+auth-oauth2 = ["openidconnect", "oauth2", "serde", "serde_json", "data-url"]
+compression = ["lz4", "flate2", "zstd", "snap"]
+default = ["compression", "tokio-runtime", "async-std-runtime", "auth-oauth2"]
 protobuf-src = ["dep:protobuf-src"]
+telemetry = ["tracing"]
+tokio-runtime = ["tokio", "tokio-util", "native-tls", "tokio-native-tls"]
+tokio-rustls-runtime = ["tokio", "tokio-util", "tokio-rustls", "rustls", "webpki-roots"]

--- a/examples/batching.rs
+++ b/examples/batching.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), pulsar::Error> {
         loop {
             println!("will send");
             let receipt_rx = producer
-                .send(TestData {
+                .send_non_blocking(TestData {
                     data: "data".to_string(),
                 })
                 .await

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), pulsar::Error> {
     let mut counter = 0usize;
     loop {
         producer
-            .send(TestData {
+            .send_non_blocking(TestData {
                 data: "data".to_string(),
             })
             .await?

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), pulsar::Error> {
         let mut counter = 0usize;
         loop {
             producer
-                .send(TestData {
+                .send_non_blocking(TestData {
                     data: "data".to_string(),
                 })
                 .await

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ pub enum ConnectionError {
     ))]
     Tls(rustls::Error),
     #[cfg(any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"))]
-    DnsName(rustls::client::InvalidDnsNameError),
+    DnsName(rustls::pki_types::InvalidDnsNameError),
     Authentication(AuthenticationError),
     NotFound,
     Canceled,
@@ -142,9 +142,9 @@ impl From<rustls::Error> for ConnectionError {
 }
 
 #[cfg(any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"))]
-impl From<rustls::client::InvalidDnsNameError> for ConnectionError {
+impl From<rustls::pki_types::InvalidDnsNameError> for ConnectionError {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    fn from(err: rustls::client::InvalidDnsNameError) -> Self {
+    fn from(err: rustls::pki_types::InvalidDnsNameError) -> Self {
         ConnectionError::DnsName(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,14 @@ pub mod reader;
 mod retry_op;
 mod service_discovery;
 
+#[cfg(all(
+    any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"),
+    not(any(feature = "tokio-runtime", feature = "async-std-runtime"))
+))]
+pub(crate) type Certificate = rustls::pki_types::CertificateDer<'static>;
+#[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
+pub(crate) type Certificate = native_tls::Certificate;
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/src/message.rs
+++ b/src/message.rs
@@ -327,7 +327,7 @@ impl tokio_util::codec::Decoder for Codec {
 
 #[cfg(any(feature = "async-std-runtime", feature = "async-std-rustls-runtime"))]
 impl asynchronous_codec::Encoder for Codec {
-    type Item = Message;
+    type Item<'a> = Message;
     type Error = ConnectionError;
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -162,8 +162,8 @@ pub struct ProducerOptions {
 /// # let message = "data".to_owned();
 /// let pulsar: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await?;
 /// let mut producer = pulsar.producer().with_name("name").build_multi_topic();
-/// let send_1 = producer.send(topic, &message).await?;
-/// let send_2 = producer.send(topic, &message).await?;
+/// let send_1 = producer.send_non_blocking(topic, &message).await?;
+/// let send_2 = producer.send_non_blocking(topic, &message).await?;
 /// send_1.await?;
 /// send_2.await?;
 /// # Ok(())
@@ -398,8 +398,8 @@ impl<Exe: Executor> Producer<Exe> {
     ///
     /// ```rust,no_run
     /// # async fn run(mut producer: pulsar::Producer<pulsar::TokioExecutor>) -> Result<(), pulsar::Error> {
-    /// let f1 = producer.send("hello").await?;
-    /// let f2 = producer.send("world").await?;
+    /// let f1 = producer.send_non_blocking("hello").await?;
+    /// let f2 = producer.send_non_blocking("world").await?;
     /// let receipt1 = f1.await?;
     /// let receipt2 = f2.await?;
     /// # Ok(())


### PR DESCRIPTION
* If you are using rustls instead of native tls version of this crate (through `tokio-rustls-runtime` or `async-std-rustls-runtime`), you HAVE TO call the [`CryptoProvider::install_default`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default) method once in your binary.