### PR TITLE
fix: Use nondurable cursors for pulsar readers

### DIFF
--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -324,6 +324,10 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         // would this clone() consume too much memory?
         let (mut config, mut joined_topics) = self.clone().validate::<T>().await?;
 
+        // Internally, the reader interface is implemented as a consumer using an exclusive,
+        // non-durable subscription
+        config.options.durable = Some(false);
+
         // the validate() function defaults sub_type to SubType::Shared,
         // but a reader's subscription is exclusive
         warn!("Subscription Type for a reader is `Exclusive`. Resetting.");


### PR DESCRIPTION
[From the Apache Pulsar documentation](https://pulsar.apache.org/docs/3.3.x/concepts-clients/#reader-interface):

> Internally, the reader interface is implemented as a consumer using an exclusive, non-durable subscription to the topic with a randomly-allocated name.

By default we set subscriptions to use a durable cursor:
https://github.com/streamnative/pulsar-rs/blob/master/PulsarApi.proto#L352

We only run into this when durable is None which can also be avoided
if we use Pulsar::reader() which also sets durable to Some(false).

However, there are cases where users may overwrite the options before
calling `into_reader()`.