### PR TITLE
Support flow messages for batch size of 1

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -146,7 +146,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                     })?;
             }
 
-            if self.remaining_messages < self.batch_size / 2 {
+            if self.remaining_messages < self.batch_size.div_ceil(2) {
                 match self
                     .connection
                     .sender()


### PR DESCRIPTION
The logic for when to send a flow message is currently "if there are fewer outstanding messages than half the batch size, request more" (`if self.remaining_messages < self.batch_size / 2`). If batch_size is set to `1`, this will never run, and the consumer will only ever receive the initial message.

By using div_ceil here, we guarantee that when remaining_messages is 0, the consumer will ask for the next message.