### PR TITLE
fix(lint): remove elidedable lifetimes.

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1178,7 +1178,7 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     }
 }
 
-impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> {
+impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
     /// sends the message through the producer that created it
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     #[deprecated = "instead use send_non_blocking"]


### PR DESCRIPTION
### Motivation

Fix the clippy validation.  

```
error: the following explicit lifetimes could be elided: 'a
    --> src/producer.rs:1181:6
     |
[11](https://github.com/streamnative/pulsar-rs/actions/runs/13383814710/job/37376880167?pr=329#step:5:12)81 | impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> {
     |      ^^                                                             ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
     = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
     |
1[18](https://github.com/streamnative/pulsar-rs/actions/runs/13383814710/job/37376880167?pr=329#step:5:19)1 - impl<'a, T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'a, T, Exe> {
1181 + impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
     |

error: could not compile `pulsar` (lib test) due to 1 previous error
```

https://github.com/streamnative/pulsar-rs/actions/runs/13391632216/job/37400455409