### PR TITLE
Update README.md to include latest pulsar version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following dependencies in your `Cargo.toml`:
 
 ```toml
 futures = "0.3"
-pulsar = "5.1"
+pulsar = "6.3.1"
 tokio = "1.0"
 ```
 


### PR DESCRIPTION
There appears to be some confusion on the front page of the repo on what version to use:

The latest release is 6.3

![Image](https://github.com/user-attachments/assets/af1fa8fe-5f07-4c97-b3d0-a77b4947a3e5)

While the readme has an older version listed:

![Image](https://github.com/user-attachments/assets/cd1a4730-8aa5-4c9e-b837-692bf0d649bf)

Given https://crates.io/crates/pulsar has 

![Image](https://github.com/user-attachments/assets/662ace16-bbdb-40cd-a526-827607defea1)

I am assuming it is a stale README, and updating it with this PR.