### PR TITLE
Remove debugging print from MessageBuilder::delay

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1157,11 +1157,6 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn delay(mut self, delay: Duration) -> Result<Self, std::time::SystemTimeError> {
         let date = SystemTime::now() + delay;
-        println!(
-            "current date: {}, deliver_at: {}",
-            SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
-            date.duration_since(UNIX_EPOCH)?.as_millis()
-        );
         self.deliver_at_time = Some(date.duration_since(UNIX_EPOCH)?.as_millis() as i64);
         Ok(self)
     }


### PR DESCRIPTION
While looking at the code, I noticed a stray println! that was not matched by any other in the project (ignoring samples, tests, and obvious logs).

This feels like a mistake, so this PR drops it.