### PR TITLE
fix(consumer): Quiet error logging on shutdown

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -110,7 +110,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
 
             let send_end_res = event_tx.send(mapper(None)).await;
             if let Err(err) = send_end_res {
-                log::error!("Error sending end event to channel - {err}");
+                log::debug!("Error sending close event to channel - {err}");
             }
 
             log::warn!("rx terminated");


### PR DESCRIPTION
When closing a consumer, the `event_tx` gets dropped causing an error log even on normal shutdown with no traffic. Lower the log level for this to avoid false error reporting.