### PR TITLE
test(producer): add unit tests for producer.rs

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1208,8 +1208,9 @@ impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use futures::executor::block_on;
+
+    use super::*;
 
     async fn drain_messages_from_full_batch(
         batch: &Batch,


### PR DESCRIPTION
I've added unit tests to producer.rs to validate the producer’s local behavior ahead of structural refactors in upcoming PRs to reduce future sizes downstream. They are intentionally broker-free to keep the feedback loop tight and deterministic.

**Tests Added:**
send_future_errors_when_sender_dropped: 
- Ensures `SendFuture` returns `Error::Producer(ProducerError::Custom(..))` when the sender side is dropped (simulating an unexpected disconnect).

message_converts_into_producer_message:
- Confirms `From<Message>` for `ProducerMessage` copies user-facing fields and leaves producer-managed fields unset.

batch_fills_on_length_threshold_and_drains: 
- Length-based fullness at `Batch::new(3, None);` verifies drain resets state and that `BatchedMessage` metadata is populated correctly.

batch_fills_on_size_threshold_even_if_length_not_reached:
- Size-based fullness at `Batch::new(10, Some(10));` drain resets size accounting.

batch_is_full_when_size_exactly_matches_threshold:
- Confirms “== threshold” counts as full.

batch_mapping_when_optional_fields_absent:
- Optional fields remain unset in metadata; payload_size equals actual payload length.

batch_storage_tracks_and_resets_size:
- Direct test of `BatchStorage` internal size tracking and reset-on-drain behavior.

**Limitations / Future work:**
The remaining behavior I wanted to test is coupled to a real Pulsar connection. Without either (a) a running broker or (b) a mockable “transport” seam that pretends to be the broker, I'm unable to drive, observe, or deterministically fail the network paths.