### PR TITLE
feat: support blocking send_non_blocking() and other RPCs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -554,6 +554,7 @@ impl<Exe: Executor> PulsarBuilder<Exe> {
         Ok(self.with_certificate_chain(v))
     }
 
+    /// The internal pending queue size for each producer on a topic partition. (default: 100)
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_outbound_channel_size(mut self, size: usize) -> Self {
         self.outbound_channel_size = Some(size);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -640,10 +640,10 @@ impl<Exe: Executor> ConnectionSender<Exe> {
     where
         F: FnOnce(Message) -> Option<R> + 'static,
     {
-        // This method is called for RPCs other than CommandSend, if the queue is full due to too
-        // many CommandSend RPCs not processed in time, we should not wait rather than fail fast
+        // This method is called for RPCs other than CommandSend. If the queue is full due to too
+        // many CommandSend RPCs not processed in time, we should wait rather than fail fast
         // because it's a client side issue that can be recovered later. Hence, set
-        // block_if_queue_full with true here.
+        // block_if_queue_full to true here.
         self.send_message_non_blocking(msg, key, extract, true)
             .await?
             .await

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -388,6 +388,9 @@ impl<Exe: Executor> Producer<Exe> {
     /// like:
     ///
     /// ```rust,no_run
+    /// use pulsar::error::{ConnectionError, Error, ProducerError};
+    ///
+    /// # async fn run(mut producer: pulsar::Producer<pulsar::TokioExecutor>) -> Result<(), pulsar::Error> {
     /// match producer.send_non_blocking("msg").await {
     ///     Ok(future) => { /* handle the send future */ }
     ///     Err(Error::Producer(ProducerError::Connection(ConnectionError::SlowDown))) => {
@@ -395,6 +398,8 @@ impl<Exe: Executor> Producer<Exe> {
     ///     }
     ///     Err(e) => { /* handle other errors */ }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Usage:

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1494,10 +1494,7 @@ mod tests {
                 Err(Error::Producer(ProducerError::Connection(ConnectionError::SlowDown))) => {
                     failed_indexes.push(i);
                 }
-                Err(e) => {
-                    error!("failed to send {}: {}", i, e);
-                    panic!();
-                }
+                Err(e) => panic!("failed to send {}: {}", i, e),
             }
         }
         info!("Messages failed due to SlowDown: {:?}", &failed_indexes);
@@ -1520,10 +1517,7 @@ mod tests {
         for (i, result) in send_results.into_iter().enumerate() {
             match result {
                 Ok(_) => {}
-                Err(e) => {
-                    error!("failed to send {}: {}", i, e);
-                    panic!();
-                }
+                Err(e) => panic!("failed to send {}: {}", i, e),
             }
         }
     }


### PR DESCRIPTION
Fixes #342

### Motivation

#312 changes connection's outbound channel from unbounded to bounded and once the channel is full, all RPC requests will fail with the `SlowDown` error. However, other RPCs like `Ack` could also be affected. This is different from other Pulsar client SDKs because only pending `Send` RPCs should be limited.

This behavior is not documented and hence very confusing.

### Modifications

Add a `block_if_queue_full` option to simulate the feature from Java client:
https://github.com/apache/pulsar/blob/14543d3fde935d1b70e3707a8b2c0294eb53dccb/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java#L241

- For `Send` RPC
  - call `async_channel::Sender::send` when this option is enabled (disabled by default)
  - keep calling `async_channel::Sender::try_send` and fail with `SlowDown` if queue is full
- For other RPCs: call `async_channel::Sender::send`

Add `block_if_queue_full` to show the difference between the option is enabled and disabled.

Additionally, add documents to this new option, as well as `send_non_blocking` because it's hard for users to know how to handle this `SlowDown` error without the documentation.