### PR TITLE
feat: Add Java-compatible partition key bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-std = { version = "^1.13.1", features = ["attributes", "unstable"], option
 async-native-tls = { version = "^0.5.0", optional = true }
 asynchronous-codec = { version = "^0.7.0", optional = true }
 bytes = "^1.9.0"
+base64 = "0.22"
 chrono = { version = "^0.4.41", default-features = false, features = ["clock", "std"] }
 crc = "^3.3.0"
 data-url = { version = "^0.3.1", optional = true }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1596,6 +1596,7 @@ pub(crate) mod messages {
                     publish_time: Utc::now().timestamp_millis() as u64,
                     replicated_from: None,
                     partition_key: message.partition_key,
+                    partition_key_b64_encoded: message.partition_key_b64_encoded,
                     ordering_key: message.ordering_key,
                     replicate_to: message.replicate_to,
                     compression: message.compression,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1260,11 +1260,11 @@ impl<Exe: Executor> Connection<Exe> {
                 Some(error.message),
             )),
             Some(Ok(msg)) => {
-                trace!("received connection response: {:?}", &msg);
+                trace!("received connection response: {:?}", msg);
                 let Some(c) = msg.command.connected else {
                     return Err(ConnectionError::Unexpected(format!(
                         "Unexpected message from pulsar: {:?}",
-                        &msg.command
+                        msg.command
                     )));
                 };
 

--- a/src/consumer/batched_message_iterator.rs
+++ b/src/consumer/batched_message_iterator.rs
@@ -51,6 +51,7 @@ impl Iterator for BatchedMessageIterator {
             let metadata = Metadata {
                 properties: batched_message.metadata.properties,
                 partition_key: batched_message.metadata.partition_key,
+                partition_key_b64_encoded: batched_message.metadata.partition_key_b64_encoded,
                 ordering_key: batched_message.metadata.ordering_key,
                 event_time: batched_message.metadata.event_time,
                 ..self.metadata.clone()
@@ -65,5 +66,77 @@ impl Iterator for BatchedMessageIterator {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::proto::SingleMessageMetadata;
+
+    #[test]
+    fn per_message_b64_flag_not_taken_from_batch_envelope() {
+        let messages = [
+            BatchedMessage {
+                metadata: SingleMessageMetadata {
+                    partition_key: Some("plain-key".into()),
+                    partition_key_b64_encoded: Some(false),
+                    payload_size: 1,
+                    ..Default::default()
+                },
+                payload: b"a".to_vec(),
+            },
+            BatchedMessage {
+                metadata: SingleMessageMetadata {
+                    partition_key: Some("YmluYXJ5".into()),
+                    partition_key_b64_encoded: Some(true),
+                    payload_size: 1,
+                    ..Default::default()
+                },
+                payload: b"b".to_vec(),
+            },
+        ];
+
+        let mut data = Vec::new();
+        for message in &messages {
+            message.serialize(&mut data);
+        }
+
+        // Envelope flag deliberately disagrees with the first message. Before the
+        // fix, `..self.metadata.clone()` leaked this onto every batch member.
+        let payload = Payload {
+            metadata: Metadata {
+                producer_name: "test".into(),
+                sequence_id: 0,
+                publish_time: 0,
+                num_messages_in_batch: Some(2),
+                partition_key_b64_encoded: Some(true),
+                ..Default::default()
+            },
+            data,
+        };
+
+        let expanded: Vec<_> = BatchedMessageIterator::new(
+            MessageIdData {
+                ledger_id: 1,
+                entry_id: 2,
+                ..Default::default()
+            },
+            payload,
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(expanded.len(), 2);
+        assert_eq!(
+            expanded[0].1.metadata.partition_key.as_deref(),
+            Some("plain-key")
+        );
+        assert_eq!(
+            expanded[0].1.metadata.partition_key_b64_encoded,
+            Some(false),
+            "per-message flag must win over the batch envelope"
+        );
+        assert_eq!(expanded[1].1.metadata.partition_key_b64_encoded, Some(true));
     }
 }

--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -579,6 +579,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                         payload: data,
                         properties,
                         partition_key: metadata.partition_key,
+                        partition_key_b64_encoded: metadata.partition_key_b64_encoded,
                         ordering_key: metadata.ordering_key,
                         event_time: metadata.event_time,
                         ..Default::default()

--- a/src/consumer/message.rs
+++ b/src/consumer/message.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
+use base64::Engine;
+
 use crate::{
     consumer::data::MessageData,
     message::proto::{MessageIdData, MessageMetadata},
-    DeserializeMessage, Payload,
+    DeserializeMessage, Error, Payload,
 };
 
 /// a message received by a consumer
@@ -42,10 +44,41 @@ impl<T> Message<T> {
         &self.message_id.id
     }
 
-    /// Get message key (partition key)
+    /// Get message key (partition key string as stored in metadata)
+    ///
+    /// When [`has_base64_encoded_key`](Self::has_base64_encoded_key) is true, this is the
+    /// Base64 encoding of the raw key bytes.
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn key(&self) -> Option<String> {
         self.payload.metadata.partition_key.clone()
+    }
+
+    /// Whether the partition key is a Base64 encoding of raw key bytes.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn has_base64_encoded_key(&self) -> bool {
+        self.payload.metadata.partition_key_b64_encoded()
+    }
+
+    /// Get the raw partition key bytes.
+    ///
+    /// If the key is Base64-encoded, it is decoded; otherwise the UTF-8 bytes of
+    /// the key string are returned. Returns `Ok(None)` when there is no key.
+    ///
+    /// Returns an error when the key is marked Base64-encoded but decoding fails.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn key_bytes(&self) -> Result<Option<Vec<u8>>, Error> {
+        match self.payload.metadata.partition_key.as_ref() {
+            None => Ok(None),
+            Some(key) if !self.has_base64_encoded_key() => Ok(Some(key.as_bytes().to_vec())),
+            Some(key) => match base64::engine::general_purpose::STANDARD.decode(key) {
+                Ok(bytes) => Ok(Some(bytes)),
+                Err(e) => Err(Error::Custom(format!(
+                    "failed to decode Base64 partition key on topic {} message_id={:?}: {e}",
+                    self.topic,
+                    self.message_id()
+                ))),
+            },
+        }
     }
 }
 
@@ -54,5 +87,79 @@ impl<T: DeserializeMessage> Message<T> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn deserialize(&self) -> T::Output {
         T::deserialize_message(&self.payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::data::MessageData;
+    use crate::message::proto::MessageIdData;
+
+    fn message_with_key(partition_key: Option<String>, b64: Option<bool>) -> Message<()> {
+        Message::new(
+            "persistent://public/default/topic",
+            MessageData {
+                id: MessageIdData {
+                    ledger_id: 1,
+                    entry_id: 2,
+                    ..Default::default()
+                },
+                batch_size: None,
+            },
+            Payload {
+                metadata: MessageMetadata {
+                    producer_name: "test".into(),
+                    sequence_id: 0,
+                    publish_time: 0,
+                    partition_key,
+                    partition_key_b64_encoded: b64,
+                    ..Default::default()
+                },
+                data: vec![],
+            },
+        )
+    }
+
+    #[test]
+    fn key_bytes_decodes_when_flag_set() {
+        let raw = b"\x00\x01binary";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(raw);
+        let msg = message_with_key(Some(encoded), Some(true));
+        assert!(msg.has_base64_encoded_key());
+        assert_eq!(msg.key_bytes().unwrap().as_deref(), Some(raw.as_slice()));
+    }
+
+    #[test]
+    fn key_bytes_uses_utf8_when_flag_unset() {
+        let msg = message_with_key(Some("plain-key".into()), Some(false));
+        assert!(!msg.has_base64_encoded_key());
+        assert_eq!(
+            msg.key_bytes().unwrap().as_deref(),
+            Some(b"plain-key".as_slice())
+        );
+    }
+
+    #[test]
+    fn key_bytes_none_without_key() {
+        let msg = message_with_key(None, None);
+        assert!(!msg.has_base64_encoded_key());
+        assert!(msg.key_bytes().unwrap().is_none());
+    }
+
+    #[test]
+    fn key_bytes_errors_on_invalid_base64() {
+        let msg = message_with_key(Some("not!!valid".into()), Some(true));
+        assert!(msg.has_base64_encoded_key());
+        let err = msg.key_bytes().unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("persistent://public/default/topic"),
+            "error should include topic: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("message_id="),
+            "error should include message id: {err_msg}"
+        );
     }
 }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -588,7 +588,7 @@ mod tests {
             debug!(
                 "connected topics for {}: {:?}",
                 consumer.subscription(),
-                &connected_topics
+                connected_topics
             );
             assert_eq!(connected_topics.len(), 2);
             assert!(connected_topics.iter().any(|t| t.ends_with(&topic1)));

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1155,6 +1155,97 @@ mod tests {
         feature = "tokio-rustls-runtime-aws-lc-rs",
         feature = "tokio-rustls-runtime-ring"
     ))]
+    async fn dead_letter_queue_preserves_key_bytes_flag() {
+        use base64::Engine;
+
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
+        let addr = "pulsar://127.0.0.1:6650";
+
+        let test_id: u16 = rand::random();
+        let topic = format!("dead_letter_queue_key_bytes_test_{test_id}");
+        let raw_key = b"\x00\x01binary-dlq-key";
+        let encoded_key = base64::engine::general_purpose::STANDARD.encode(raw_key);
+
+        let message_data = TestData {
+            topic: topic.clone(),
+            msg: rand::random(),
+        };
+
+        let mut message = <&TestData>::serialize_message(&message_data).unwrap();
+        message.partition_key = Some(encoded_key.clone());
+        message.partition_key_b64_encoded = Some(true);
+        message.ordering_key = Some(b"ordering_key".to_vec());
+
+        let dead_letter_topic = format!("{topic}_dlq");
+        let dead_letter_policy = DeadLetterPolicy {
+            max_redeliver_count: 1,
+            dead_letter_topic: dead_letter_topic.clone(),
+        };
+
+        let client: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
+
+        let mut consumer: Consumer<TestData, _> = client
+            .consumer()
+            .with_topic(topic.clone())
+            .with_subscription("nack_key_bytes")
+            .with_subscription_type(SubType::Shared)
+            .with_dead_letter_policy(dead_letter_policy)
+            .build()
+            .await
+            .unwrap();
+
+        let mut dlq_consumer: Consumer<TestData, _> = client
+            .clone()
+            .consumer()
+            .with_topic(dead_letter_topic)
+            .with_subscription("dead_letter_topic_key_bytes")
+            .with_subscription_type(SubType::Shared)
+            .build()
+            .await
+            .unwrap();
+
+        client.send(&topic, message).await.unwrap().await.unwrap();
+
+        let msg = recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(message_data, msg.deserialize().unwrap());
+        assert!(msg.has_base64_encoded_key());
+        assert_eq!(
+            msg.key_bytes().unwrap().as_deref(),
+            Some(raw_key.as_slice())
+        );
+        consumer.nack(&msg).await.unwrap();
+
+        let dlq_msg = recv_within(&mut dlq_consumer, DEFAULT_RECV_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(message_data, dlq_msg.deserialize().unwrap());
+        assert_eq!(
+            dlq_msg.metadata().partition_key.as_deref(),
+            Some(encoded_key.as_str()),
+            "Base64 partition key should be preserved when the message is sent to the DLQ"
+        );
+        assert_eq!(
+            dlq_msg.metadata().partition_key_b64_encoded,
+            Some(true),
+            "partition key b64 flag should be preserved when the message is sent to the DLQ"
+        );
+        assert!(dlq_msg.has_base64_encoded_key());
+        assert_eq!(
+            dlq_msg.key_bytes().unwrap().as_deref(),
+            Some(raw_key.as_slice())
+        );
+        dlq_consumer.ack(&dlq_msg).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn failover() {
         let _result = log::set_logger(&MULTI_LOGGER);
         log::set_max_level(LevelFilter::Debug);

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -169,7 +169,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
                     .filter(|t| regex.is_match(t))
                     .collect();
 
-                trace!("matched topics {:?} (regex: {})", matched_topics, &regex);
+                trace!("matched topics {:?} (regex: {})", matched_topics, regex);
 
                 topics.append(&mut matched_topics);
             }
@@ -380,19 +380,19 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
                     Poll::Pending => {}
                     Poll::Ready(Some(Ok(msg))) => result = Some(msg),
                     Poll::Ready(None) => {
-                        error!("Unexpected end of stream for pulsar topic {}", &topic);
+                        error!("Unexpected end of stream for pulsar topic {}", topic);
                         topics_to_remove.push(topic.clone());
                     }
                     Poll::Ready(Some(Err(e))) => {
                         error!(
                             "Unexpected error consuming from pulsar topic {}: {}",
-                            &topic, e
+                            topic, e
                         );
                         topics_to_remove.push(topic.clone());
                     }
                 }
             } else {
-                eprintln!("BUG: Missing consumer for topic {}", &topic);
+                eprintln!("BUG: Missing consumer for topic {}", topic);
             }
             self.existing_topics.push_back(topic);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ mod tests {
 
             let data = msg.deserialize().unwrap();
             if data.as_str() != send_data {
-                panic!("Unexpected payload in &str test: {}", &data);
+                panic!("Unexpected payload in &str test: {}", data);
             }
         }
 
@@ -475,7 +475,7 @@ mod tests {
             consumer.ack(&msg).await.unwrap();
             let data = msg.deserialize();
             if data.as_slice() != send_data {
-                panic!("Unexpected payload in &[u8] test: {:?}", &data);
+                panic!("Unexpected payload in &[u8] test: {:?}", data);
             }
         }
     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -962,13 +962,13 @@ where
         error!(
             "send_message: connection {} disconnected, reconnecting producer for topic: {}",
             connection.id(),
-            &topic
+            topic
         );
 
         if let Err(e) = connection.sender().close_producer(producer_id).await {
             error!(
                 "could not close producer {:?}({}) for topic {}: {:?}",
-                producer_name, producer_id, &topic, e
+                producer_name, producer_id, topic, e
             );
         }
 
@@ -1761,7 +1761,7 @@ mod tests {
                 Err(e) => panic!("failed to send {}: {}", i, e),
             }
         }
-        info!("Messages failed due to SlowDown: {:?}", &failed_indexes);
+        info!("Messages failed due to SlowDown: {:?}", failed_indexes);
         assert!(!failed_indexes.is_empty());
 
         let mut producer = pulsar

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -10,6 +10,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use base64::Engine;
 use futures::{
     channel::{mpsc, oneshot},
     future::{self, try_join_all, Either},
@@ -74,6 +75,8 @@ pub struct Message {
     pub properties: HashMap<String, String>,
     /// key to decide partition for the message
     pub partition_key: ::std::option::Option<String>,
+    /// whether [`partition_key`](Self::partition_key) is a Base64 encoding of raw key bytes
+    pub partition_key_b64_encoded: ::std::option::Option<bool>,
     /// key to decide partition for the message
     pub ordering_key: ::std::option::Option<Vec<u8>>,
     /// Override namespace's replication
@@ -96,6 +99,8 @@ pub(crate) struct ProducerMessage {
     pub properties: HashMap<String, String>,
     ///key to decide partition for the msg
     pub partition_key: ::std::option::Option<String>,
+    /// whether [`partition_key`](Self::partition_key) is Base64-encoded raw key bytes
+    pub partition_key_b64_encoded: ::std::option::Option<bool>,
     ///key to decide partition for the msg
     pub ordering_key: ::std::option::Option<Vec<u8>>,
     /// Override namespace's replication
@@ -127,6 +132,7 @@ impl From<Message> for ProducerMessage {
             payload: m.payload,
             properties: m.properties,
             partition_key: m.partition_key,
+            partition_key_b64_encoded: m.partition_key_b64_encoded,
             ordering_key: m.ordering_key,
             replicate_to: m.replicate_to,
             event_time: m.event_time,
@@ -756,6 +762,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     metadata: proto::SingleMessageMetadata {
                         properties,
                         partition_key: message.partition_key,
+                        partition_key_b64_encoded: message.partition_key_b64_encoded,
                         ordering_key: message.ordering_key,
                         payload_size: message.payload.len() as i32,
                         event_time: message.event_time,
@@ -1357,6 +1364,7 @@ pub struct MessageBuilder<'a, T, Exe: Executor> {
     producer: &'a mut Producer<Exe>,
     properties: HashMap<String, String>,
     partition_key: Option<String>,
+    partition_key_b64_encoded: Option<bool>,
     ordering_key: Option<Vec<u8>>,
     deliver_at_time: Option<i64>,
     event_time: Option<u64>,
@@ -1371,6 +1379,7 @@ impl<'a, Exe: Executor> MessageBuilder<'a, (), Exe> {
             producer,
             properties: HashMap::new(),
             partition_key: None,
+            partition_key_b64_encoded: None,
             ordering_key: None,
             deliver_at_time: None,
             event_time: None,
@@ -1387,6 +1396,7 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
             producer: self.producer,
             properties: self.properties,
             partition_key: self.partition_key,
+            partition_key_b64_encoded: self.partition_key_b64_encoded,
             ordering_key: self.ordering_key,
             deliver_at_time: self.deliver_at_time,
             event_time: self.event_time,
@@ -1394,10 +1404,12 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
         }
     }
 
-    /// sets the message's partition key
+    /// sets the message's partition key as a UTF-8 string
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_partition_key<S: Into<String>>(mut self, partition_key: S) -> Self {
-        self.partition_key = Some(partition_key.into());
+        let (key, b64) = utf8_partition_key(partition_key);
+        self.partition_key = Some(key);
+        self.partition_key_b64_encoded = Some(b64);
         self
     }
 
@@ -1408,13 +1420,27 @@ impl<'a, T, Exe: Executor> MessageBuilder<'a, T, Exe> {
         self
     }
 
-    /// sets the message's partition key
+    /// sets the message's partition key as a UTF-8 string
     ///
     /// this is the same as `with_partition_key`, this method is added for
     /// more consistency with other clients
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_key<S: Into<String>>(mut self, partition_key: S) -> Self {
-        self.partition_key = Some(partition_key.into());
+        let (key, b64) = utf8_partition_key(partition_key);
+        self.partition_key = Some(key);
+        self.partition_key_b64_encoded = Some(b64);
+        self
+    }
+
+    /// sets the message's partition key from raw bytes
+    ///
+    /// The bytes are Base64-encoded into `partition_key` and
+    /// `partition_key_b64_encoded` is set to `true`.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn with_key_bytes<S: AsRef<[u8]>>(mut self, key: S) -> Self {
+        let (encoded, b64) = partition_key_from_bytes(key.as_ref());
+        self.partition_key = Some(encoded);
+        self.partition_key_b64_encoded = Some(b64);
         self
     }
 
@@ -1474,6 +1500,7 @@ impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
             producer,
             properties,
             partition_key,
+            partition_key_b64_encoded,
             ordering_key,
             content,
             deliver_at_time,
@@ -1483,11 +1510,26 @@ impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
         let mut message = T::serialize_message(content)?;
         message.properties = properties;
         message.partition_key = partition_key;
+        message.partition_key_b64_encoded = partition_key_b64_encoded;
         message.ordering_key = ordering_key;
         message.event_time = event_time;
         message.deliver_at_time = deliver_at_time;
         producer.send_non_blocking(message).await
     }
+}
+
+/// Encode raw key bytes for the partition key wire field.
+///
+/// Returns the Base64-encoded key string and `partition_key_b64_encoded = true`.
+pub(crate) fn partition_key_from_bytes(key: &[u8]) -> (String, bool) {
+    (base64::engine::general_purpose::STANDARD.encode(key), true)
+}
+
+/// Mark a UTF-8 partition key.
+///
+/// Returns the key string and `partition_key_b64_encoded = false`.
+pub(crate) fn utf8_partition_key(key: impl Into<String>) -> (String, bool) {
+    (key.into(), false)
 }
 
 #[cfg(test)]
@@ -1531,6 +1573,7 @@ mod tests {
             payload: b"hello".to_vec(),
             properties: props.clone(),
             partition_key: Some("key".into()),
+            partition_key_b64_encoded: Some(true),
             ordering_key: Some(vec![1, 2, 3]),
             replicate_to: vec!["r1".into(), "r2".into()],
             event_time: Some(42),
@@ -1543,6 +1586,7 @@ mod tests {
         assert_eq!(pm.payload, m.payload);
         assert_eq!(pm.properties, m.properties);
         assert_eq!(pm.partition_key, m.partition_key);
+        assert_eq!(pm.partition_key_b64_encoded, Some(true));
         assert_eq!(pm.ordering_key, m.ordering_key);
         assert_eq!(pm.replicate_to, m.replicate_to);
         assert_eq!(pm.event_time, m.event_time);
@@ -1553,6 +1597,139 @@ mod tests {
         assert!(pm.num_messages_in_batch.is_none());
         assert!(pm.compression.is_none());
         assert!(pm.uncompressed_size.is_none());
+    }
+
+    #[test]
+    fn partition_key_from_bytes_encodes_and_sets_b64_flag() {
+        let raw_key = b"\x00\x01binary-key";
+        let (encoded, b64) = partition_key_from_bytes(raw_key);
+        assert_eq!(
+            encoded,
+            base64::engine::general_purpose::STANDARD.encode(raw_key)
+        );
+        assert!(b64);
+
+        let message = Message {
+            payload: b"payload".to_vec(),
+            partition_key: Some(encoded.clone()),
+            partition_key_b64_encoded: Some(b64),
+            ..Default::default()
+        };
+        let pm: ProducerMessage = message.into();
+        assert_eq!(pm.partition_key.as_deref(), Some(encoded.as_str()));
+        assert_eq!(pm.partition_key_b64_encoded, Some(true));
+    }
+
+    #[test]
+    fn utf8_partition_key_sets_b64_flag_false() {
+        let (key, b64) = utf8_partition_key("plain-key");
+        assert_eq!(key, "plain-key");
+        assert!(!b64);
+
+        let message = Message {
+            payload: b"payload".to_vec(),
+            partition_key: Some(key),
+            partition_key_b64_encoded: Some(b64),
+            ..Default::default()
+        };
+        let pm: ProducerMessage = message.into();
+        assert_eq!(pm.partition_key.as_deref(), Some("plain-key"));
+        assert_eq!(pm.partition_key_b64_encoded, Some(false));
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn key_bytes_round_trip() {
+        use crate::{
+            consumer::Consumer, message::proto::command_subscribe::SubType, DeserializeMessage,
+            Payload,
+        };
+        use futures::StreamExt;
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        struct KeyBytesTestData {
+            data: String,
+        }
+
+        impl SerializeMessage for &KeyBytesTestData {
+            fn serialize_message(input: Self) -> Result<Message, Error> {
+                let payload =
+                    serde_json::to_vec(input).map_err(|e| Error::Custom(e.to_string()))?;
+                Ok(Message {
+                    payload,
+                    ..Default::default()
+                })
+            }
+        }
+
+        impl DeserializeMessage for KeyBytesTestData {
+            type Output = Result<KeyBytesTestData, serde_json::Error>;
+
+            fn deserialize_message(payload: &Payload) -> Self::Output {
+                serde_json::from_slice(&payload.data)
+            }
+        }
+
+        let _result = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
+
+        let pulsar: Pulsar<_> = Pulsar::builder("pulsar://127.0.0.1:6650", TokioExecutor)
+            .build()
+            .await
+            .unwrap();
+        let topic = format!("key_bytes_round_trip_{}", rand::random::<u16>());
+        let raw_key = b"\x00\x01\x02avro-like-key";
+
+        let mut producer = pulsar.producer().with_topic(&topic).build().await.unwrap();
+
+        let mut consumer: Consumer<KeyBytesTestData, _> = pulsar
+            .consumer()
+            .with_topic(&topic)
+            .with_subscription(format!("sub_{}", rand::random::<u16>()))
+            .with_subscription_type(SubType::Exclusive)
+            .build()
+            .await
+            .unwrap();
+
+        let data = KeyBytesTestData {
+            data: "hello-key-bytes".to_string(),
+        };
+        producer
+            .create_message()
+            .with_content(&data)
+            .with_key_bytes(raw_key)
+            .send_non_blocking()
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), consumer.next())
+            .await
+            .expect("timed out waiting for key_bytes round-trip message")
+            .unwrap()
+            .unwrap();
+        assert!(msg.has_base64_encoded_key());
+        assert_eq!(
+            msg.key_bytes().unwrap().as_deref(),
+            Some(raw_key.as_slice())
+        );
+        assert_eq!(
+            msg.key().as_deref(),
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .encode(raw_key)
+                    .as_str()
+            )
+        );
+        assert_eq!(msg.metadata().partition_key_b64_encoded, Some(true));
+        assert_eq!(msg.deserialize().unwrap(), data);
+        consumer.ack(&msg).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -228,7 +228,7 @@ mod tests {
         let topic = format!("test_reader_{}", rand::random::<u16>());
         let dead_letter_policy = DeadLetterPolicy {
             max_redeliver_count: 1,
-            dead_letter_topic: format!("{}_dead_letter", &topic),
+            dead_letter_topic: format!("{}_dead_letter", topic),
         };
         let client: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
         let mut reader: Reader<TestData, _> = client
@@ -252,7 +252,7 @@ mod tests {
 
         let policy = reader.dead_letter_policy().unwrap();
         assert_eq!(policy.max_redeliver_count, 1);
-        assert_eq!(policy.dead_letter_topic, format!("{}_dead_letter", &topic));
+        assert_eq!(policy.dead_letter_topic, format!("{}_dead_letter", topic));
         assert_eq!(reader.subscription(), "test_reader_subscription");
         assert_eq!(reader.sub_type(), SubType::Exclusive);
         assert_eq!(reader.batch_size(), None);

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -282,7 +282,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
         let topics = match partitions {
             0 => vec![topic],
             _ => (0..partitions)
-                .map(|n| format!("{}-partition-{}", &topic, n))
+                .map(|n| format!("{}-partition-{}", topic, n))
                 .collect(),
         };
         try_join_all(topics.into_iter().map(|topic| {


### PR DESCRIPTION
Wire partition_key_b64_encoded through produce, consume, and DLQ so binary keys match the Java keyBytes/getKeyBytes contract.