### PR TITLE
ci: apply the standalone broker configuration from env

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,12 +52,11 @@ jobs:
             -d \
             -e GITHUB_ACTIONS=true -e CI=true \
             -e PULSAR_PREFIX_advertisedAddress=127.0.0.1 \
-            -e PULSAR_PREFIX_advertisedListeners=pulsar://127.0.0.1:6650 \
             -e PULSAR_PREFIX_brokerServicePort=6650 \
             -e PULSAR_PREFIX_webServicePort=8080 \
             -e PULSAR_PREFIX_topicLevelPoliciesEnabled=true \
             apachepulsar/pulsar:${{ matrix.pulsar-version }} \
-            bin/pulsar standalone
+            bash -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
 
       - name: Wait for Pulsar readiness
         timeout-minutes: 3


### PR DESCRIPTION
`bin/pulsar standalone` does not read the `PULSAR_PREFIX_*` variables, so none of the broker settings the workflow passes were actually applied. This worked because all of the env vars match the defaults.

Also removes the `advertisedListeners` env var, which was invalid its prior form and the override is not needed anyway.


```sh
❯ docker run --name probe -d -e PULSAR_PREFIX_advertisedAddress=9.9.9.9 \ # <---
          apachepulsar/pulsar:3.0.8 bin/pulsar standalone
  sleep 20
  docker exec probe curl -s http://127.0.0.1:8080/admin/v2/brokers/configuration/runtime \
          | tr ',' '\n' | grep '"advertisedAddress"'
  docker rm -f probe

"advertisedAddress":"localhost" # <---

❯ docker run --name probe -d -e PULSAR_PREFIX_advertisedAddress=9.9.9.9 \ # <---
          apachepulsar/pulsar:3.0.8 bash -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
  sleep 20
  docker exec probe curl -s http://127.0.0.1:8080/admin/v2/brokers/configuration/runtime \
          | tr ',' '\n' | grep '"advertisedAddress"'
  docker rm -f probe

"advertisedAddress":"9.9.9.9" # <---
