### PR TITLE
style: remove redundant references in formatting macro arguments

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1260,11 +1260,11 @@ impl<Exe: Executor> Connection<Exe> {
                 Some(error.message),
             )),
             Some(Ok(msg)) => {
-                trace!("received connection response: {:?}", &msg);
+                trace!("received connection response: {:?}", msg);
                 let Some(c) = msg.command.connected else {
                     return Err(ConnectionError::Unexpected(format!(
                         "Unexpected message from pulsar: {:?}",
-                        &msg.command
+                        msg.command
                     )));
                 };
 

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -588,7 +588,7 @@ mod tests {
             debug!(
                 "connected topics for {}: {:?}",
                 consumer.subscription(),
-                &connected_topics
+                connected_topics
             );
             assert_eq!(connected_topics.len(), 2);
             assert!(connected_topics.iter().any(|t| t.ends_with(&topic1)));

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -169,7 +169,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
                     .filter(|t| regex.is_match(t))
                     .collect();
 
-                trace!("matched topics {:?} (regex: {})", matched_topics, &regex);
+                trace!("matched topics {:?} (regex: {})", matched_topics, regex);
 
                 topics.append(&mut matched_topics);
             }
@@ -380,19 +380,19 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
                     Poll::Pending => {}
                     Poll::Ready(Some(Ok(msg))) => result = Some(msg),
                     Poll::Ready(None) => {
-                        error!("Unexpected end of stream for pulsar topic {}", &topic);
+                        error!("Unexpected end of stream for pulsar topic {}", topic);
                         topics_to_remove.push(topic.clone());
                     }
                     Poll::Ready(Some(Err(e))) => {
                         error!(
                             "Unexpected error consuming from pulsar topic {}: {}",
-                            &topic, e
+                            topic, e
                         );
                         topics_to_remove.push(topic.clone());
                     }
                 }
             } else {
-                eprintln!("BUG: Missing consumer for topic {}", &topic);
+                eprintln!("BUG: Missing consumer for topic {}", topic);
             }
             self.existing_topics.push_back(topic);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ mod tests {
 
             let data = msg.deserialize().unwrap();
             if data.as_str() != send_data {
-                panic!("Unexpected payload in &str test: {}", &data);
+                panic!("Unexpected payload in &str test: {}", data);
             }
         }
 
@@ -475,7 +475,7 @@ mod tests {
             consumer.ack(&msg).await.unwrap();
             let data = msg.deserialize();
             if data.as_slice() != send_data {
-                panic!("Unexpected payload in &[u8] test: {:?}", &data);
+                panic!("Unexpected payload in &[u8] test: {:?}", data);
             }
         }
     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -955,13 +955,13 @@ where
         error!(
             "send_message: connection {} disconnected, reconnecting producer for topic: {}",
             connection.id(),
-            &topic
+            topic
         );
 
         if let Err(e) = connection.sender().close_producer(producer_id).await {
             error!(
                 "could not close producer {:?}({}) for topic {}: {:?}",
-                producer_name, producer_id, &topic, e
+                producer_name, producer_id, topic, e
             );
         }
 
@@ -1584,7 +1584,7 @@ mod tests {
                 Err(e) => panic!("failed to send {}: {}", i, e),
             }
         }
-        info!("Messages failed due to SlowDown: {:?}", &failed_indexes);
+        info!("Messages failed due to SlowDown: {:?}", failed_indexes);
         assert!(!failed_indexes.is_empty());
 
         let mut producer = pulsar

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -228,7 +228,7 @@ mod tests {
         let topic = format!("test_reader_{}", rand::random::<u16>());
         let dead_letter_policy = DeadLetterPolicy {
             max_redeliver_count: 1,
-            dead_letter_topic: format!("{}_dead_letter", &topic),
+            dead_letter_topic: format!("{}_dead_letter", topic),
         };
         let client: Pulsar<_> = Pulsar::builder(addr, TokioExecutor).build().await.unwrap();
         let mut reader: Reader<TestData, _> = client
@@ -252,7 +252,7 @@ mod tests {
 
         let policy = reader.dead_letter_policy().unwrap();
         assert_eq!(policy.max_redeliver_count, 1);
-        assert_eq!(policy.dead_letter_topic, format!("{}_dead_letter", &topic));
+        assert_eq!(policy.dead_letter_topic, format!("{}_dead_letter", topic));
         assert_eq!(reader.subscription(), "test_reader_subscription");
         assert_eq!(reader.sub_type(), SubType::Exclusive);
         assert_eq!(reader.batch_size(), None);

--- a/src/service_discovery.rs
+++ b/src/service_discovery.rs
@@ -282,7 +282,7 @@ impl<Exe: Executor> ServiceDiscovery<Exe> {
         let topics = match partitions {
             0 => vec![topic],
             _ => (0..partitions)
-                .map(|n| format!("{}-partition-{}", &topic, n))
+                .map(|n| format!("{}-partition-{}", topic, n))
                 .collect(),
         };
         try_join_all(topics.into_iter().map(|topic| {


### PR DESCRIPTION
Fixes #426.

## What

Removes the explicit `&` from 15 formatting-macro arguments that clippy 1.98.0 flags as
`useless_borrows_in_formatting`. Formatting macros already take their arguments by
reference, so the borrow does nothing.

Applied with `cargo clippy --fix` — every hunk is a bare `&` removal. 15 insertions,
15 deletions, no behavior change.

| File | Fixes |
| --- | --- |
| `src/connection.rs` | 2 |
| `src/consumer/mod.rs` | 1 |
| `src/consumer/multi.rs` | 4 |
| `src/lib.rs` | 2 |
| `src/producer.rs` | 3 |
| `src/reader.rs` | 2 |
| `src/service_discovery.rs` | 1 |

## Why now

These predate any pending change — reproduced on unmodified `master`. The lint job uses
unpinned `dtolnay/rust-toolchain@stable`, and `master` has not been linted since Rust
1.98.0 was released, so the next run on any PR will fail. See #426 for detail, including
a suggestion about pinning the CI toolchain (not addressed here).

## Verification

Run locally on rustc 1.98.0, on this branch alone (master + this commit):

- `cargo clippy --tests --features telemetry,protobuf-src,admin-api -- -D warnings` — exit 0
- `cargo clippy --tests --no-default-features --features compression,tokio-rustls-runtime,async-std-rustls-runtime,auth-oauth2,telemetry,protobuf-src -- -D warnings` — exit 0
- `cargo fmt --all --check` — clean
- `cargo test --features tokio-runtime --lib` — 38 passed, 0 failed
- `cargo test --features tokio-runtime --doc` — 20 passed, 0 failed

That is every job in `.github/workflows/rust.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016225V4xL2DjNvgKMDQcu7Y
