### PR TITLE
feat(consumer): track acknowledgments of batched entries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,12 +52,11 @@ jobs:
             -d \
             -e GITHUB_ACTIONS=true -e CI=true \
             -e PULSAR_PREFIX_advertisedAddress=127.0.0.1 \
-            -e PULSAR_PREFIX_advertisedListeners=pulsar://127.0.0.1:6650 \
             -e PULSAR_PREFIX_brokerServicePort=6650 \
             -e PULSAR_PREFIX_webServicePort=8080 \
             -e PULSAR_PREFIX_topicLevelPoliciesEnabled=true \
             apachepulsar/pulsar:${{ matrix.pulsar-version }} \
-            bin/pulsar standalone
+            bash -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
 
       - name: Wait for Pulsar readiness
         timeout-minutes: 3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,7 @@ jobs:
             -e PULSAR_PREFIX_brokerServicePort=6650 \
             -e PULSAR_PREFIX_webServicePort=8080 \
             -e PULSAR_PREFIX_topicLevelPoliciesEnabled=true \
+            -e PULSAR_PREFIX_acknowledgmentAtBatchIndexLevelEnabled=true \
             apachepulsar/pulsar:${{ matrix.pulsar-version }} \
             bash -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features:
 - TLS connection;
 - Configurable executor (Tokio or async-std);
 - Automatic reconnection with exponential back off;
-- Message batching;
+- Message batching, with per-message acknowledgment of batched entries and batch-index acknowledgment where the broker supports it;
 - Compression with LZ4, zlib, zstd or Snappy (can be deactivated with Cargo features);
 - Telemetry using [tracing](https://github.com/tokio-rs/tracing) crate (can be activated with Cargo features).
 

--- a/src/consumer/batch_acknowledgment.rs
+++ b/src/consumer/batch_acknowledgment.rs
@@ -1,0 +1,571 @@
+//! Acks of messages inside batched entries.
+//!
+//! The broker stores a producer batch as one entry, and an ack without an `ack_set` acks the
+//! whole entry. After the first ack of any message in the batch entry, the subscription never
+//! delivers the sibling messages again. The tracker keeps a bitset of unacked messages per
+//! delivered entry, so an entry is only acked outright once every message in it has been acked.
+
+use std::collections::HashMap;
+
+use crate::message::proto::MessageIdData;
+
+/// How a message that arrived inside a batched entry is acknowledged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BatchAcknowledgment {
+    /// Ack the whole entry on the first ack of any of its messages. The subscription moves
+    /// past the entry, unacked siblings included, and never delivers them again.
+    #[default]
+    Entry,
+    /// Hold acks back until every message of the entry has been acked, then ack the entry.
+    Tracked,
+    /// Send the entry's remaining bitset with every ack. A broker with
+    /// `acknowledgmentAtBatchIndexLevelEnabled` redelivers only those messages; one without it
+    /// ignores the bitset and behaves as under [`Self::Tracked`].
+    Indexed,
+}
+
+/// Bitset of an entry's unacked message indexes, in the `ack_set` wire layout: bit `i` is bit
+/// `i % 64` of word `i / 64`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AckSet {
+    words: Vec<u64>,
+}
+
+impl AckSet {
+    pub(crate) fn full(batch_size: u32) -> Self {
+        let mut words = vec![u64::MAX; (batch_size as usize).div_ceil(64)];
+        let used_in_last = batch_size % 64;
+        if let Some(last) = words.last_mut().filter(|_| used_in_last != 0) {
+            *last = (1u64 << used_in_last) - 1;
+        }
+        AckSet { words }
+    }
+
+    pub(crate) fn and(&mut self, other: &AckSet) {
+        for (index, word) in self.words.iter_mut().enumerate() {
+            *word &= other.words.get(index).copied().unwrap_or(0);
+        }
+    }
+
+    pub(crate) fn get(&self, index: u32) -> bool {
+        self.words
+            .get(index as usize / 64)
+            .is_some_and(|word| word & (1u64 << (index % 64)) != 0)
+    }
+
+    pub(crate) fn clear(&mut self, index: u32) {
+        if let Some(word) = self.words.get_mut(index as usize / 64) {
+            *word &= !(1u64 << (index % 64));
+        }
+    }
+
+    pub(crate) fn clear_through(&mut self, index: u32) {
+        let last = index as usize / 64;
+        let kept_in_last = u64::MAX.checked_shl(index % 64 + 1).unwrap_or(0);
+        for (position, word) in self.words.iter_mut().take(last + 1).enumerate() {
+            *word &= if position == last { kept_in_last } else { 0 };
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.words.iter().all(|word| *word == 0)
+    }
+
+    /// The wire words, trailing zero words dropped.
+    pub(crate) fn to_words(&self) -> Vec<i64> {
+        let used = self
+            .words
+            .iter()
+            .rposition(|word| *word != 0)
+            .map_or(0, |position| position + 1);
+        self.words[..used].iter().map(|word| *word as i64).collect()
+    }
+}
+
+impl From<&[i64]> for AckSet {
+    fn from(words: &[i64]) -> Self {
+        AckSet {
+            words: words.iter().map(|word| *word as u64).collect(),
+        }
+    }
+}
+
+/// The unacked messages of each delivered batched entry.
+#[derive(Debug)]
+pub(crate) struct BatchAcknowledgmentTracker {
+    mode: BatchAcknowledgment,
+    entries: HashMap<MessageIdData, AckSet>,
+}
+
+impl BatchAcknowledgmentTracker {
+    pub(crate) fn new(mode: BatchAcknowledgment) -> Self {
+        BatchAcknowledgmentTracker {
+            mode,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Whether entries are held until every message in them is acked.
+    pub(crate) fn tracks_entries(&self) -> bool {
+        self.mode != BatchAcknowledgment::Entry
+    }
+
+    /// Starts tracking a delivered entry, replacing the state of any earlier delivery of it.
+    pub(crate) fn track(&mut self, entry: MessageIdData, unacked: AckSet) {
+        if !self.tracks_entries() {
+            return;
+        }
+        if unacked.is_empty() {
+            self.entries.remove(&entry);
+        } else {
+            self.entries.insert(entry, unacked);
+        }
+    }
+
+    /// Records an ack and returns the id to send to the broker, if anything is sent.
+    #[must_use]
+    pub(crate) fn acknowledge(
+        &mut self,
+        message_id: MessageIdData,
+        cumulative: bool,
+    ) -> Option<MessageIdData> {
+        if !self.tracks_entries() {
+            return Some(message_id);
+        }
+        let entry = message_id.entry();
+        if cumulative {
+            let acked = entry.position();
+            self.entries.retain(|id, _| id.position() >= acked);
+        }
+        let Some((batch_index, batch_size)) = message_id.batch() else {
+            self.entries.remove(&entry);
+            return Some(entry);
+        };
+
+        // An entry not delivered on this connection is acked against a full bitset, and nothing
+        // is kept for it. Under Indexed the broker intersects that bitset with its own; under
+        // Tracked the ack is dropped, since the entry comes back whole and the acks of that
+        // delivery complete it.
+        let mut untracked = AckSet::full(batch_size);
+        let ack_set = self.entries.get_mut(&entry).unwrap_or(&mut untracked);
+        if cumulative {
+            ack_set.clear_through(batch_index);
+        } else {
+            ack_set.clear(batch_index);
+        }
+
+        if ack_set.is_empty() {
+            self.entries.remove(&entry);
+            Some(entry)
+        } else if self.mode == BatchAcknowledgment::Indexed {
+            Some(MessageIdData {
+                ack_set: ack_set.to_words(),
+                ..entry
+            })
+        } else if cumulative {
+            Some(entry.prev_entry())
+        } else {
+            None
+        }
+    }
+
+    /// Forgets an entry the broker is about to redeliver; the redelivery tracks it again.
+    pub(crate) fn forget(&mut self, entry: &MessageIdData) {
+        self.entries.remove(entry);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    #[cfg(test)]
+    fn tracked(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(ledger_id: u64, entry_id: u64) -> MessageIdData {
+        MessageIdData {
+            ledger_id,
+            entry_id,
+            partition: Some(-1),
+            ..Default::default()
+        }
+    }
+
+    fn batched(ledger_id: u64, entry_id: u64, batch_index: i32, batch_size: i32) -> MessageIdData {
+        MessageIdData {
+            batch_index: Some(batch_index),
+            batch_size: Some(batch_size),
+            ..entry(ledger_id, entry_id)
+        }
+    }
+
+    fn with_ack_set(id: MessageIdData, ack_set: Vec<i64>) -> MessageIdData {
+        MessageIdData { ack_set, ..id }
+    }
+
+    /// What the broker reports as unacked for an entry of `batch_size` messages.
+    fn reported(batch_size: u32, broker_ack_set: &[i64]) -> AckSet {
+        let mut ack_set = AckSet::full(batch_size);
+        ack_set.and(&AckSet::from(broker_ack_set));
+        ack_set
+    }
+
+    fn tracked() -> BatchAcknowledgmentTracker {
+        BatchAcknowledgmentTracker::new(BatchAcknowledgment::Tracked)
+    }
+
+    fn indexed() -> BatchAcknowledgmentTracker {
+        BatchAcknowledgmentTracker::new(BatchAcknowledgment::Indexed)
+    }
+
+    #[test]
+    fn ack_set_wire_layout() {
+        assert_eq!(AckSet::full(3).to_words(), vec![0b111]);
+        let mut set = AckSet::full(3);
+        set.clear(1);
+        assert_eq!(set.to_words(), vec![0b101]);
+        assert!(set.get(0));
+        assert!(!set.get(1));
+        assert!(set.get(2));
+        assert!(!set.get(3));
+
+        assert_eq!(AckSet::full(64).to_words(), vec![u64::MAX as i64]);
+        assert_eq!(AckSet::full(65).to_words(), vec![u64::MAX as i64, 1]);
+        assert_eq!(
+            AckSet::full(128).to_words(),
+            vec![u64::MAX as i64, u64::MAX as i64]
+        );
+        let mut set = AckSet::full(65);
+        set.clear(64);
+        assert_eq!(set.to_words(), vec![u64::MAX as i64]);
+
+        assert_eq!(AckSet::full(0).to_words(), Vec::<i64>::new());
+        assert!(AckSet::full(0).is_empty());
+    }
+
+    #[test]
+    fn ack_set_clearing_and_emptiness() {
+        let mut set = AckSet::full(4);
+        set.clear_through(2);
+        assert_eq!(set.to_words(), vec![0b1000]);
+        assert!(!set.is_empty());
+        set.clear(3);
+        assert!(set.is_empty());
+        assert_eq!(set.to_words(), Vec::<i64>::new());
+
+        let mut set = AckSet::full(2);
+        set.clear(7);
+        set.clear(200);
+        assert_eq!(set.to_words(), vec![0b11]);
+        set.clear_through(100);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn ack_set_clears_through_word_boundaries() {
+        let mut set = AckSet::full(130);
+        set.clear_through(63);
+        assert_eq!(set.to_words(), vec![0, u64::MAX as i64, 0b11]);
+        set.clear_through(64);
+        assert_eq!(set.to_words(), vec![0, (u64::MAX - 1) as i64, 0b11]);
+        set.clear_through(128);
+        assert_eq!(set.to_words(), vec![0, 0, 0b10]);
+
+        // An index past the end clears the whole set without walking to it.
+        let mut set = AckSet::full(3);
+        set.clear_through(u32::MAX);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn ack_set_and_with_broker_set() {
+        let mut set = AckSet::full(5);
+        set.and(&AckSet::from(&[0b10100i64][..]));
+        assert_eq!(set.to_words(), vec![0b10100]);
+
+        let mut set = AckSet::full(70);
+        set.and(&AckSet::from(&[0b1i64][..]));
+        assert_eq!(set.to_words(), vec![0b1]);
+    }
+
+    #[test]
+    fn entry_mode_sends_ids_as_they_are_and_tracks_nothing() {
+        let mut tracker = BatchAcknowledgmentTracker::new(BatchAcknowledgment::Entry);
+        assert!(!tracker.tracks_entries());
+        tracker.track(entry(1, 2), AckSet::full(3));
+        assert_eq!(tracker.tracked(), 0);
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 3), false),
+            Some(batched(1, 2, 1, 3))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 3), true),
+            Some(batched(1, 2, 1, 3))
+        );
+    }
+
+    #[test]
+    fn non_batched_id_is_sent_as_is() {
+        let mut tracker = tracked();
+        assert_eq!(tracker.acknowledge(entry(1, 2), false), Some(entry(1, 2)));
+        assert_eq!(indexed().acknowledge(entry(1, 2), true), Some(entry(1, 2)));
+        // A batch index without a batch size does not make a batched id.
+        let mut id = entry(1, 2);
+        id.batch_index = Some(3);
+        assert_eq!(tracker.acknowledge(id, false), Some(entry(1, 2)));
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn tracked_acks_are_held_until_the_entry_is_fully_acked() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), AckSet::full(3));
+        assert_eq!(tracker.acknowledge(batched(1, 2, 1, 3), false), None);
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 3), false),
+            None,
+            "acking the same index twice must not complete the entry"
+        );
+        assert_eq!(tracker.acknowledge(batched(1, 2, 0, 3), false), None);
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 2, 3), false),
+            Some(entry(1, 2))
+        );
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn indexed_acks_send_the_remaining_bitset() {
+        let mut tracker = indexed();
+        tracker.track(entry(1, 2), AckSet::full(3));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 3), false),
+            Some(with_ack_set(entry(1, 2), vec![0b101]))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 2, 3), false),
+            Some(with_ack_set(entry(1, 2), vec![0b001]))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 0, 3), false),
+            Some(entry(1, 2)),
+            "the last ack is a plain ack of the entry"
+        );
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn tracked_cumulative_ack_inside_an_entry_acks_the_preceding_entry() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), AckSet::full(3));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 3), true),
+            Some(entry(1, 1))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 2, 3), true),
+            Some(entry(1, 2))
+        );
+
+        // The first entry of a ledger acks up to (ledger, -1).
+        tracker.track(entry(1, 0), AckSet::full(2));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 0, 0, 2), true),
+            Some(entry(1, u64::MAX))
+        );
+    }
+
+    #[test]
+    fn indexed_cumulative_ack_clears_through_the_acked_index() {
+        let mut tracker = indexed();
+        tracker.track(entry(1, 2), AckSet::full(4));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 4), true),
+            Some(with_ack_set(entry(1, 2), vec![0b1100]))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 3, 4), true),
+            Some(entry(1, 2))
+        );
+    }
+
+    #[test]
+    fn broker_ack_set_marks_indexes_as_already_acked() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), reported(4, &[0b1010]));
+        assert_eq!(tracker.acknowledge(batched(1, 2, 1, 4), false), None);
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 3, 4), false),
+            Some(entry(1, 2))
+        );
+    }
+
+    #[test]
+    fn acks_of_untracked_entries_leave_no_state() {
+        // Tracked: dropped, and acking the rest of the entry cannot complete it either, since
+        // nothing was kept.
+        let mut tracker = tracked();
+        assert_eq!(tracker.acknowledge(batched(1, 2, 0, 2), false), None);
+        assert_eq!(tracker.tracked(), 0);
+        assert_eq!(tracker.acknowledge(batched(1, 2, 1, 2), false), None);
+        assert_eq!(tracker.tracked(), 0);
+        // A single-message batch is acked whole right away.
+        assert_eq!(
+            tracker.acknowledge(batched(1, 4, 0, 1), false),
+            Some(entry(1, 4))
+        );
+        assert_eq!(tracker.tracked(), 0);
+
+        // Indexed: each ack carries a bitset computed from a full one, and the broker is the one
+        // that intersects them.
+        let mut tracker = indexed();
+        assert_eq!(
+            tracker.acknowledge(batched(1, 3, 1, 2), false),
+            Some(with_ack_set(entry(1, 3), vec![0b01]))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 3, 0, 2), false),
+            Some(with_ack_set(entry(1, 3), vec![0b10]))
+        );
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn cumulative_acks_of_untracked_entries_need_no_state() {
+        let mut tracker = tracked();
+        assert_eq!(
+            tracker.acknowledge(batched(1, 5, 1, 4), true),
+            Some(entry(1, 4))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 5, 3, 4), true),
+            Some(entry(1, 5))
+        );
+        assert_eq!(tracker.tracked(), 0);
+
+        let mut tracker = indexed();
+        assert_eq!(
+            tracker.acknowledge(batched(1, 5, 1, 4), true),
+            Some(with_ack_set(entry(1, 5), vec![0b1100]))
+        );
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn acking_a_completed_entry_again_leaves_no_state() {
+        let mut tracker = indexed();
+        tracker.track(entry(1, 2), AckSet::full(2));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 0, 2), false),
+            Some(with_ack_set(entry(1, 2), vec![0b10]))
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 2), false),
+            Some(entry(1, 2))
+        );
+        assert_eq!(tracker.tracked(), 0);
+        // A repeat ack is resolved against a full bitset and kept nowhere. The broker intersects
+        // bitsets, so this cannot reopen an entry it has already acked.
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 2), false),
+            Some(with_ack_set(entry(1, 2), vec![0b01]))
+        );
+        assert_eq!(tracker.tracked(), 0);
+
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), AckSet::full(1));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 0, 1), false),
+            Some(entry(1, 2))
+        );
+        assert_eq!(tracker.acknowledge(batched(1, 2, 0, 2), false), None);
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn redelivery_replaces_the_tracked_state() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), AckSet::full(2));
+        assert_eq!(tracker.acknowledge(batched(1, 2, 0, 2), false), None);
+        tracker.track(entry(1, 2), AckSet::full(2));
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 2), false),
+            None,
+            "the index acked before the redelivery must be acked again"
+        );
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 0, 2), false),
+            Some(entry(1, 2))
+        );
+    }
+
+    #[test]
+    fn cumulative_ack_drops_the_tracking_of_earlier_entries() {
+        let mut tracker = tracked();
+        for (ledger_id, entry_id) in [(1, 1), (1, 2), (1, 3), (2, 0)] {
+            tracker.track(entry(ledger_id, entry_id), AckSet::full(2));
+        }
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 0, 2), true),
+            Some(entry(1, 1))
+        );
+        assert_eq!(tracker.tracked(), 3, "entries before (1, 2) are covered");
+        assert_eq!(
+            tracker.acknowledge(batched(1, 2, 1, 2), true),
+            Some(entry(1, 2))
+        );
+        assert_eq!(tracker.tracked(), 2);
+        assert_eq!(
+            tracker.acknowledge(entry(1, 3), true),
+            Some(entry(1, 3)),
+            "a non-batched id acks its entry whole"
+        );
+        assert_eq!(tracker.tracked(), 1, "only (2, 0) is left");
+
+        // The (ledger, -1) position covers earlier ledgers but not the ledger itself.
+        tracker.track(entry(1, 9), AckSet::full(2));
+        assert_eq!(
+            tracker.acknowledge(batched(2, 0, 0, 2), true),
+            Some(entry(2, u64::MAX))
+        );
+        assert_eq!(tracker.tracked(), 1);
+        assert_eq!(
+            tracker.acknowledge(batched(2, 0, 1, 2), false),
+            Some(entry(2, 0))
+        );
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn whole_entry_ack_by_a_non_batched_id_drops_its_tracking() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 1), AckSet::full(2));
+        assert_eq!(tracker.acknowledge(entry(1, 1), false), Some(entry(1, 1)));
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn an_entry_the_broker_reports_fully_acked_is_not_tracked() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 1), AckSet::full(2));
+        tracker.track(entry(1, 1), reported(2, &[0]));
+        assert_eq!(tracker.tracked(), 0);
+    }
+
+    #[test]
+    fn forget_and_clear_drop_tracked_entries() {
+        let mut tracker = tracked();
+        tracker.track(entry(1, 2), AckSet::full(2));
+        tracker.track(entry(1, 3), AckSet::full(2));
+        tracker.forget(&entry(1, 2));
+        assert_eq!(tracker.tracked(), 1);
+        tracker.clear();
+        assert_eq!(tracker.tracked(), 0);
+    }
+}

--- a/src/consumer/batched_message_iterator.rs
+++ b/src/consumer/batched_message_iterator.rs
@@ -1,25 +1,37 @@
 use crate::{
+    consumer::batch_acknowledgment::AckSet,
     error::ConnectionError,
     message::{parse_batched_message, proto::MessageIdData, BatchedMessage, Metadata},
     Payload,
 };
 
+/// Splits a batched entry into its messages, each with its own id.
 pub struct BatchedMessageIterator {
     messages: std::vec::IntoIter<BatchedMessage>,
     message_id: MessageIdData,
     metadata: Metadata,
     total_messages: u32,
     current_index: u32,
+    unacknowledged: AckSet,
+    skipped: u32,
 }
 
 impl BatchedMessageIterator {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub fn new(message_id: MessageIdData, payload: Payload) -> Result<Self, ConnectionError> {
+    pub fn new(
+        message_id: MessageIdData,
+        payload: Payload,
+        broker_ack_set: &[i64],
+    ) -> Result<Self, ConnectionError> {
         let total_messages = payload
             .metadata
             .num_messages_in_batch
             .expect("expected batched message") as u32;
         let messages = parse_batched_message(total_messages, &payload.data)?;
+        let mut unacknowledged = AckSet::full(total_messages);
+        if !broker_ack_set.is_empty() {
+            unacknowledged.and(&AckSet::from(broker_ack_set));
+        }
 
         Ok(Self {
             messages: messages.into_iter(),
@@ -27,7 +39,19 @@ impl BatchedMessageIterator {
             total_messages,
             metadata: payload.metadata,
             current_index: 0,
+            unacknowledged,
+            skipped: 0,
         })
+    }
+
+    /// Messages not yielded because the broker reported them as acked.
+    pub fn skipped(&self) -> u32 {
+        self.skipped
+    }
+
+    /// The entry's unacked messages, the broker's bitset applied.
+    pub fn into_ack_set(self) -> AckSet {
+        self.unacknowledged
     }
 }
 
@@ -36,15 +60,22 @@ impl Iterator for BatchedMessageIterator {
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn next(&mut self) -> Option<Self::Item> {
-        let remaining = self.total_messages - self.current_index;
-        if remaining == 0 {
-            return None;
-        }
-        let index = self.current_index;
-        self.current_index += 1;
-        if let Some(batched_message) = self.messages.next() {
+        loop {
+            if self.current_index == self.total_messages {
+                return None;
+            }
+            let index = self.current_index;
+            self.current_index += 1;
+            let batched_message = self.messages.next()?;
+
+            if !self.unacknowledged.get(index) {
+                self.skipped += 1;
+                continue;
+            }
+
             let id = MessageIdData {
                 batch_index: Some(index as i32),
+                batch_size: Some(self.total_messages as i32),
                 ..self.message_id.clone()
             };
 
@@ -62,9 +93,7 @@ impl Iterator for BatchedMessageIterator {
                 data: batched_message.payload,
             };
 
-            Some((id, payload))
-        } else {
-            None
+            return Some((id, payload));
         }
     }
 }
@@ -74,58 +103,133 @@ mod tests {
     use super::*;
     use crate::message::proto::SingleMessageMetadata;
 
+    fn batched_payload_with(
+        messages: &[(SingleMessageMetadata, &[u8])],
+        envelope: Metadata,
+    ) -> Payload {
+        let mut data = Vec::new();
+        for (metadata, payload) in messages {
+            BatchedMessage {
+                metadata: SingleMessageMetadata {
+                    payload_size: payload.len() as i32,
+                    ..metadata.clone()
+                },
+                payload: payload.to_vec(),
+            }
+            .serialize(&mut data);
+        }
+        Payload {
+            metadata: Metadata {
+                num_messages_in_batch: Some(messages.len() as i32),
+                ..envelope
+            },
+            data,
+        }
+    }
+
+    fn batched_payload(payloads: &[&[u8]]) -> Payload {
+        let messages: Vec<_> = payloads
+            .iter()
+            .map(|payload| (SingleMessageMetadata::default(), *payload))
+            .collect();
+        batched_payload_with(&messages, Metadata::default())
+    }
+
+    fn entry() -> MessageIdData {
+        MessageIdData {
+            ledger_id: 1,
+            entry_id: 2,
+            partition: Some(-1),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn yields_every_message_with_batch_index_and_size() {
+        let mut iterator =
+            BatchedMessageIterator::new(entry(), batched_payload(&[b"a", b"b", b"c"]), &[])
+                .unwrap();
+        let messages: Vec<_> = iterator.by_ref().collect();
+        assert_eq!(iterator.skipped(), 0);
+        assert_eq!(iterator.into_ack_set().to_words(), vec![0b111]);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|(id, payload)| (id.batch_index, id.batch_size, payload.data.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                (Some(0), Some(3), b"a".to_vec()),
+                (Some(1), Some(3), b"b".to_vec()),
+                (Some(2), Some(3), b"c".to_vec()),
+            ]
+        );
+        assert!(messages.iter().all(|(id, _)| id.entry() == entry()));
+    }
+
+    #[test]
+    fn skips_messages_the_broker_reports_as_acked() {
+        let mut iterator =
+            BatchedMessageIterator::new(entry(), batched_payload(&[b"a", b"b", b"c"]), &[0b101])
+                .unwrap();
+        let messages: Vec<_> = iterator.by_ref().collect();
+        assert_eq!(iterator.skipped(), 1);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|(id, payload)| (id.batch_index, payload.data.clone()))
+                .collect::<Vec<_>>(),
+            vec![(Some(0), b"a".to_vec()), (Some(2), b"c".to_vec())]
+        );
+        assert_eq!(iterator.into_ack_set().to_words(), vec![0b101]);
+    }
+
+    #[test]
+    fn the_broker_set_is_masked_to_the_batch_size() {
+        let iterator =
+            BatchedMessageIterator::new(entry(), batched_payload(&[b"a", b"b"]), &[0b1111])
+                .unwrap();
+        assert_eq!(iterator.into_ack_set(), AckSet::full(2));
+    }
+
+    #[test]
+    fn an_entry_the_broker_reports_fully_acked_yields_nothing() {
+        let mut iterator =
+            BatchedMessageIterator::new(entry(), batched_payload(&[b"a", b"b"]), &[0]).unwrap();
+        assert_eq!(iterator.by_ref().count(), 0);
+        assert_eq!(iterator.skipped(), 2);
+        assert!(iterator.into_ack_set().is_empty());
+    }
+
     #[test]
     fn per_message_b64_flag_not_taken_from_batch_envelope() {
         let messages = [
-            BatchedMessage {
-                metadata: SingleMessageMetadata {
+            (
+                SingleMessageMetadata {
                     partition_key: Some("plain-key".into()),
                     partition_key_b64_encoded: Some(false),
-                    payload_size: 1,
                     ..Default::default()
                 },
-                payload: b"a".to_vec(),
-            },
-            BatchedMessage {
-                metadata: SingleMessageMetadata {
+                &b"a"[..],
+            ),
+            (
+                SingleMessageMetadata {
                     partition_key: Some("YmluYXJ5".into()),
                     partition_key_b64_encoded: Some(true),
-                    payload_size: 1,
                     ..Default::default()
                 },
-                payload: b"b".to_vec(),
-            },
+                &b"b"[..],
+            ),
         ];
-
-        let mut data = Vec::new();
-        for message in &messages {
-            message.serialize(&mut data);
-        }
-
-        // Envelope flag deliberately disagrees with the first message. Before the
-        // fix, `..self.metadata.clone()` leaked this onto every batch member.
-        let payload = Payload {
-            metadata: Metadata {
-                producer_name: "test".into(),
-                sequence_id: 0,
-                publish_time: 0,
-                num_messages_in_batch: Some(2),
-                partition_key_b64_encoded: Some(true),
-                ..Default::default()
-            },
-            data,
+        // The envelope flag deliberately disagrees with the first message.
+        let envelope = Metadata {
+            partition_key_b64_encoded: Some(true),
+            ..Default::default()
         };
 
-        let expanded: Vec<_> = BatchedMessageIterator::new(
-            MessageIdData {
-                ledger_id: 1,
-                entry_id: 2,
-                ..Default::default()
-            },
-            payload,
-        )
-        .unwrap()
-        .collect();
+        let expanded: Vec<_> =
+            BatchedMessageIterator::new(entry(), batched_payload_with(&messages, envelope), &[])
+                .unwrap()
+                .collect();
 
         assert_eq!(expanded.len(), 2);
         assert_eq!(

--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -9,8 +9,8 @@ use regex::Regex;
 
 use crate::{
     consumer::{
-        config::ConsumerConfig, data::DeadLetterPolicy, multi::MultiTopicConsumer,
-        options::ConsumerOptions, topic::TopicConsumer, InnerConsumer,
+        batch_acknowledgment::BatchAcknowledgment, config::ConsumerConfig, data::DeadLetterPolicy,
+        multi::MultiTopicConsumer, options::ConsumerOptions, topic::TopicConsumer, InnerConsumer,
     },
     message::proto::command_subscribe::SubType,
     reader::{Reader, State},
@@ -32,6 +32,7 @@ pub struct ConsumerBuilder<Exe: Executor> {
     batch_size: Option<u32>,
     unacked_message_resend_delay: Option<Duration>,
     dead_letter_policy: Option<DeadLetterPolicy>,
+    batch_acknowledgment: BatchAcknowledgment,
     consumer_options: Option<ConsumerOptions>,
     namespace: Option<String>,
     topic_refresh: Option<Duration>,
@@ -53,6 +54,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
             // TODO what should this default to? None seems incorrect..
             unacked_message_resend_delay: None,
             dead_letter_policy: None,
+            batch_acknowledgment: BatchAcknowledgment::default(),
             consumer_options: None,
             namespace: None,
             topic_refresh: None,
@@ -175,6 +177,29 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         self
     }
 
+    /// How messages inside a batched entry are acknowledged.
+    ///
+    /// Defaults to [`BatchAcknowledgment::Entry`], which is what earlier releases did: the
+    /// first ack of any message acks the whole entry, unacked siblings included. See the enum
+    /// for the other modes; `Indexed` needs `acknowledgmentAtBatchIndexLevelEnabled` on the
+    /// broker, which is the default from Pulsar >= 4.1.
+    ///
+    /// [`BatchAcknowledgment::Tracked`] and [`BatchAcknowledgment::Indexed`] hold an entry
+    /// until every message in it is acked. An application that _never_ acks some of its messages
+    /// accumulates held entries, and can hit the broker's `maxUnackedMessagesPerConsumer`,
+    /// after which delivery stops. Applications should ack or nack every message rather than
+    /// dropping it.
+    ///
+    /// Under [`BatchAcknowledgment::Tracked`] a redelivered entry comes back as a whole, and has
+    /// to be acked again. A dead letter policy will move the entire entry, including messages
+    /// that were already acked. Under [`BatchAcknowledgment::Indexed`] only the messages still
+    /// outstanding come back or are moved.
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn with_batch_acknowledgment(mut self, batch_acknowledgment: BatchAcknowledgment) -> Self {
+        self.batch_acknowledgment = batch_acknowledgment;
+        self
+    }
+
     // Checks the builder for inconsistencies
     // returns a config and a list of topics with associated brokers
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
@@ -191,6 +216,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
             unacked_message_resend_delay,
             consumer_options,
             dead_letter_policy,
+            batch_acknowledgment,
             namespace: _,
             topic_refresh: _,
         } = self;
@@ -253,6 +279,14 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
             warn!("Subscription Type not specified. Defaulting to `Shared`.");
             SubType::Shared
         });
+        if batch_acknowledgment == BatchAcknowledgment::Tracked && dead_letter_policy.is_some() {
+            warn!(
+                "BatchAcknowledgment::Tracked with a dead letter policy moves whole \
+                 entries, including already acked messages. Use BatchAcknowledgment::Indexed \
+                 with `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker to allow \
+                 individual messages to be sent to the DLQ."
+            );
+        }
 
         let config = ConsumerConfig {
             subscription,
@@ -263,6 +297,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
             unacked_message_redelivery_delay: unacked_message_resend_delay,
             options: consumer_options.unwrap_or_default(),
             dead_letter_policy,
+            batch_acknowledgment,
         };
         Ok((config, topics))
     }

--- a/src/consumer/config.rs
+++ b/src/consumer/config.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use crate::{
-    consumer::{data::DeadLetterPolicy, options::ConsumerOptions},
+    consumer::{
+        batch_acknowledgment::BatchAcknowledgment, data::DeadLetterPolicy, options::ConsumerOptions,
+    },
     message::proto::command_subscribe::SubType,
 };
 
@@ -28,4 +30,6 @@ pub struct ConsumerConfig {
     pub(crate) options: ConsumerOptions,
     /// dead letter policy
     pub(crate) dead_letter_policy: Option<DeadLetterPolicy>,
+    /// acknowledgment of messages inside batched entries
+    pub(crate) batch_acknowledgment: BatchAcknowledgment,
 }

--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -13,6 +13,7 @@ use futures::{
 use crate::{
     connection::Connection,
     consumer::{
+        batch_acknowledgment::{BatchAcknowledgment, BatchAcknowledgmentTracker},
         batched_message_iterator::BatchedMessageIterator,
         data::{DeadLetterPolicy, EngineEvent, EngineMessage},
         options::ConsumerOptions,
@@ -49,6 +50,7 @@ pub struct ConsumerEngine<Exe: Executor> {
     remaining_messages: i64,
     unacked_message_redelivery_delay: Option<Duration>,
     unacked_messages: HashMap<MessageIdData, Instant>,
+    batch_acknowledgments: BatchAcknowledgmentTracker,
     dead_letter_policy: Option<DeadLetterPolicy>,
     options: ConsumerOptions,
 }
@@ -69,6 +71,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         batch_size: u32,
         unacked_message_redelivery_delay: Option<Duration>,
         dead_letter_policy: Option<DeadLetterPolicy>,
+        batch_acknowledgment: BatchAcknowledgment,
         options: ConsumerOptions,
     ) -> ConsumerEngine<Exe> {
         let (event_tx, event_rx) = mpsc::unbounded();
@@ -89,6 +92,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             remaining_messages: batch_size as i64,
             unacked_message_redelivery_delay,
             unacked_messages: HashMap::new(),
+            batch_acknowledgments: BatchAcknowledgmentTracker::new(batch_acknowledgment),
             dead_letter_policy,
             options,
         }
@@ -287,6 +291,15 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 true
             }
             Some(EngineMessage::Nack(message_id)) => {
+                // The broker redelivers whole entries.
+                let message_id = if self.batch_acknowledgments.tracks_entries() {
+                    let entry = message_id.entry();
+                    self.unacked_messages.remove(&entry);
+                    self.batch_acknowledgments.forget(&entry);
+                    entry
+                } else {
+                    message_id
+                };
                 if let Err(e) = self
                     .connection
                     .sender()
@@ -323,6 +336,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                     } else {
                         for i in h.iter() {
                             self.unacked_messages.remove(i);
+                            self.batch_acknowledgments.forget(i);
                         }
                     }
                 }
@@ -342,8 +356,28 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn ack(&mut self, message_id: MessageIdData, cumulative: bool) {
-        // FIXME: this does not handle cumulative acks
-        self.unacked_messages.remove(&message_id);
+        let Some(message_id) = self
+            .batch_acknowledgments
+            .acknowledge(message_id, cumulative)
+        else {
+            return;
+        };
+        // The redelivery timer is stopped based on what the ack completes:
+        // - every entry before the id for a cumulative ack
+        // - the id's own entry once no `ack_set` is left
+        let entry_done = message_id.ack_set.is_empty();
+        if cumulative {
+            let acked = message_id.position();
+            self.unacked_messages
+                .retain(|id, _| id.position() > acked || (id.position() == acked && !entry_done));
+        } else if entry_done {
+            self.unacked_messages.remove(&message_id);
+        }
+        self.send_ack(message_id, cumulative).await;
+    }
+
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    async fn send_ack(&mut self, message_id: MessageIdData, cumulative: bool) {
         let res = self
             .connection
             .sender()
@@ -536,7 +570,20 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         };
 
         let payloads = if payload.metadata.num_messages_in_batch.is_some() {
-            BatchedMessageIterator::new(message.message_id, payload)?.collect()
+            let entry = message.message_id.entry();
+            let broker_ack_set = if self.batch_acknowledgments.tracks_entries() {
+                &message.ack_set[..]
+            } else {
+                &[]
+            };
+            let mut messages =
+                BatchedMessageIterator::new(message.message_id, payload, broker_ack_set)?;
+            let payloads: Vec<_> = messages.by_ref().collect();
+            // The broker charges no permits for the messages it reported as acked.
+            self.remaining_messages += messages.skipped() as i64;
+            self.batch_acknowledgments
+                .track(entry, messages.into_ack_set());
+            payloads
         } else {
             vec![(message.message_id, payload)]
         };
@@ -616,7 +663,13 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 Error::Custom("tx closed".to_string())
             })?;
         if let Some(duration) = self.unacked_message_redelivery_delay {
-            self.unacked_messages.insert(message_id, now + duration);
+            // Keyed per entry under tracking, as the broker redelivers whole entries.
+            let key = if self.batch_acknowledgments.tracks_entries() {
+                message_id.entry()
+            } else {
+                message_id
+            };
+            self.unacked_messages.insert(key, now + duration);
         }
         Ok(())
     }
@@ -654,6 +707,8 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
 
         self.remaining_messages = self.batch_size as i64;
         self.messages_rx = Some(messages);
+        // The new subscription redelivers everything still unacked.
+        self.batch_acknowledgments.clear();
 
         Ok(())
     }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,5 +1,6 @@
 //! Topic subscriptions
 
+mod batch_acknowledgment;
 mod batched_message_iterator;
 pub mod builder;
 pub mod config;
@@ -17,6 +18,7 @@ use std::{
     time::Duration,
 };
 
+pub use batch_acknowledgment::BatchAcknowledgment;
 pub use builder::ConsumerBuilder;
 use chrono::{DateTime, Utc};
 pub use data::{DeadLetterPolicy, EngineMessage};
@@ -109,6 +111,8 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a single message
+    ///
+    /// For a message from a batched entry, see [`ConsumerBuilder::with_batch_acknowledgment`].
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
@@ -118,6 +122,9 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a single message with a given ID.
+    ///
+    /// An ID for a message inside a batched entry must carry the `batch_index` and
+    /// `batch_size` it was delivered with; without them the whole entry is acknowledged.
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn ack_with_id(
         &mut self,
@@ -131,6 +138,8 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a message and all the preceding messages
+    ///
+    /// For a message from a batched entry, see [`ConsumerBuilder::with_batch_acknowledgment`].
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack(&mut self, msg: &Message<T>) -> Result<(), ConsumerError> {
         match &mut self.inner {
@@ -140,6 +149,9 @@ impl<T: DeserializeMessage, Exe: Executor> Consumer<T, Exe> {
     }
 
     /// acknowledges a message and all the preceding messages with a given ID.
+    ///
+    /// An ID for a message inside a batched entry must carry the `batch_index` and
+    /// `batch_size` it was delivered with; without them the whole entry is acknowledged.
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn cumulative_ack_with_id(
         &mut self,
@@ -1916,5 +1928,467 @@ mod tests {
         );
 
         consumer.ack(&msg).await.unwrap();
+    }
+
+    // Acks of messages inside batched entries. The `indexed_*` tests need
+    // `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker, as set for the standalone
+    // container in CI; the others hold either way.
+
+    /// A fresh topic for batched entries, and the settings its consumers share.
+    struct BatchedTopic {
+        client: Pulsar<TokioExecutor>,
+        name: String,
+        sub_type: SubType,
+        mode: BatchAcknowledgment,
+    }
+
+    impl BatchedTopic {
+        async fn new(test: &str, sub_type: SubType, mode: BatchAcknowledgment) -> Self {
+            init_logger();
+            BatchedTopic {
+                client: new_client().await,
+                name: format!("batch_ack_{test}_{}", rand::random::<u16>()),
+                sub_type,
+                mode,
+            }
+        }
+
+        fn consumer(&self) -> ConsumerBuilder<TokioExecutor> {
+            self.client
+                .consumer()
+                .with_topic(&self.name)
+                .with_subscription("batch_ack")
+                .with_subscription_type(self.sub_type)
+                .with_batch_acknowledgment(self.mode)
+        }
+
+        async fn subscribe(&self) -> Consumer<TestData, TokioExecutor> {
+            self.consumer().build().await.unwrap()
+        }
+
+        /// Closes the consumer and subscribes again, so the broker redelivers whatever the
+        /// subscription still holds.
+        async fn resubscribe(
+            &self,
+            mut consumer: Consumer<TestData, TokioExecutor>,
+        ) -> Consumer<TestData, TokioExecutor> {
+            consumer.close().await.unwrap();
+            drop(consumer);
+            self.subscribe().await
+        }
+
+        async fn producer(&self, batch_size: u32) -> producer::Producer<TokioExecutor> {
+            self.client
+                .producer()
+                .with_topic(&self.name)
+                .with_options(producer::ProducerOptions {
+                    batch_size: Some(batch_size),
+                    ..Default::default()
+                })
+                .build()
+                .await
+                .unwrap()
+        }
+
+        /// Publishes `count` messages as one batched entry.
+        async fn publish_batch(
+            &self,
+            producer: &mut producer::Producer<TokioExecutor>,
+            first: u32,
+            count: u32,
+        ) -> Vec<TestData> {
+            let messages: Vec<TestData> = (first..first + count)
+                .map(|msg| TestData {
+                    topic: self.name.clone(),
+                    msg,
+                })
+                .collect();
+            let receipts = producer.send_all(&messages).await.unwrap();
+            producer.send_batch().await.unwrap();
+            try_join_all(receipts).await.unwrap();
+            messages
+        }
+    }
+
+    async fn receive(
+        consumer: &mut Consumer<TestData, TokioExecutor>,
+        count: usize,
+    ) -> Vec<Message<TestData>> {
+        let mut messages = Vec::with_capacity(count);
+        for _ in 0..count {
+            messages.push(recv_within(consumer, DEFAULT_RECV_TIMEOUT).await.unwrap());
+        }
+        messages
+    }
+
+    fn payloads(messages: &[Message<TestData>]) -> Vec<TestData> {
+        messages.iter().map(|m| m.deserialize().unwrap()).collect()
+    }
+
+    fn batch_indexes(messages: &[Message<TestData>]) -> Vec<Option<i32>> {
+        messages
+            .iter()
+            .map(|m| m.message_id().batch_index)
+            .collect()
+    }
+
+    async fn assert_nothing_left(consumer: &mut Consumer<TestData, TokioExecutor>) {
+        if let Ok(msg) = recv_within(consumer, Duration::from_secs(2)).await {
+            panic!(
+                "subscription still holds {:?} ({:?})",
+                msg.deserialize().unwrap(),
+                msg.message_id()
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_entry_is_acked_once_every_message_is_acked() {
+        let topic = BatchedTopic::new("entry", SubType::Shared, BatchAcknowledgment::Tracked).await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(5).await;
+        let published = topic.publish_batch(&mut producer, 0, 5).await;
+
+        let received = receive(&mut consumer, 5).await;
+        assert_eq!(payloads(&received), published);
+        let entry = received[0].message_id().entry();
+        assert!(received
+            .iter()
+            .all(|m| m.message_id().entry() == entry && m.message_id().batch_size == Some(5)));
+
+        // Four of the five acked: the entry is not, and comes back whole.
+        for msg in &received[..4] {
+            consumer.ack(msg).await.unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 5).await;
+        assert_eq!(payloads(&redelivered), published);
+        assert!(redelivered.iter().all(|m| m.message_id().entry() == entry));
+
+        for msg in &redelivered {
+            consumer.ack(msg).await.unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn indexed_ack_redelivers_only_unacked_messages() {
+        let topic =
+            BatchedTopic::new("indexed", SubType::Shared, BatchAcknowledgment::Indexed).await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(5).await;
+        let published = topic.publish_batch(&mut producer, 0, 5).await;
+
+        let received = receive(&mut consumer, 5).await;
+        assert_eq!(payloads(&received), published);
+        for index in [0, 1, 3] {
+            consumer.ack(&received[index]).await.unwrap();
+        }
+
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 2).await;
+        assert_eq!(batch_indexes(&redelivered), vec![Some(2), Some(4)]);
+        assert_eq!(
+            payloads(&redelivered),
+            vec![published[2].clone(), published[4].clone()]
+        );
+        assert_nothing_left(&mut consumer).await;
+
+        for msg in &redelivered {
+            consumer.ack(msg).await.unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_cumulative_ack_inside_an_entry_acks_the_preceding_entries() {
+        let topic = BatchedTopic::new(
+            "cumulative",
+            SubType::Exclusive,
+            BatchAcknowledgment::Tracked,
+        )
+        .await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(3).await;
+        let first = topic.publish_batch(&mut producer, 0, 3).await;
+        let second = topic.publish_batch(&mut producer, 3, 3).await;
+
+        let received = receive(&mut consumer, 6).await;
+        assert_eq!(payloads(&received), [first, second.clone()].concat());
+        assert_ne!(
+            received[0].message_id().entry(),
+            received[3].message_id().entry()
+        );
+
+        // Acking up to the middle of the second entry acks the first entry and leaves the
+        // second to be redelivered whole.
+        consumer.cumulative_ack(&received[4]).await.unwrap();
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&redelivered), second);
+        assert_nothing_left(&mut consumer).await;
+
+        consumer.cumulative_ack(&redelivered[2]).await.unwrap();
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_acks_by_id_count_toward_the_entry() {
+        let topic = BatchedTopic::new("by_id", SubType::Shared, BatchAcknowledgment::Tracked).await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(3).await;
+        let published = topic.publish_batch(&mut producer, 0, 3).await;
+
+        let received = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&received), published);
+        for msg in &received[..2] {
+            consumer
+                .ack_with_id(&topic.name, msg.message_id().clone())
+                .await
+                .unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&redelivered), published);
+
+        for msg in &redelivered {
+            consumer
+                .ack_with_id(&topic.name, msg.message_id().clone())
+                .await
+                .unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_nack_redelivers_the_whole_entry() {
+        let topic = BatchedTopic::new("nack", SubType::Shared, BatchAcknowledgment::Tracked).await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(4).await;
+        let published = topic.publish_batch(&mut producer, 0, 4).await;
+
+        let received = receive(&mut consumer, 4).await;
+        assert_eq!(payloads(&received), published);
+        for msg in &received[..3] {
+            consumer.ack(msg).await.unwrap();
+        }
+        consumer.nack(&received[3]).await.unwrap();
+
+        // The entry comes back whole, already acked messages included, and has to be acked
+        // whole again.
+        let redelivered = receive(&mut consumer, 4).await;
+        assert_eq!(payloads(&redelivered), published);
+        for msg in &redelivered {
+            consumer.ack(msg).await.unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn indexed_nack_redelivers_only_unacked_messages() {
+        let topic = BatchedTopic::new(
+            "indexed_nack",
+            SubType::Shared,
+            BatchAcknowledgment::Indexed,
+        )
+        .await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(5).await;
+        let published = topic.publish_batch(&mut producer, 0, 5).await;
+
+        let received = receive(&mut consumer, 5).await;
+        assert_eq!(payloads(&received), published);
+        for index in [0, 1, 3] {
+            consumer.ack(&received[index]).await.unwrap();
+        }
+        consumer.nack(&received[2]).await.unwrap();
+
+        let redelivered = receive(&mut consumer, 2).await;
+        assert_eq!(batch_indexes(&redelivered), vec![Some(2), Some(4)]);
+        assert_eq!(
+            payloads(&redelivered),
+            vec![published[2].clone(), published[4].clone()]
+        );
+        assert_nothing_left(&mut consumer).await;
+
+        for msg in &redelivered {
+            consumer.ack(msg).await.unwrap();
+        }
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn indexed_cumulative_ack_redelivers_only_the_unacked_tail() {
+        let topic = BatchedTopic::new(
+            "indexed_cumulative",
+            SubType::Exclusive,
+            BatchAcknowledgment::Indexed,
+        )
+        .await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(3).await;
+        let first = topic.publish_batch(&mut producer, 0, 3).await;
+        let second = topic.publish_batch(&mut producer, 3, 3).await;
+
+        let received = receive(&mut consumer, 6).await;
+        assert_eq!(payloads(&received), [first, second.clone()].concat());
+        consumer.cumulative_ack(&received[4]).await.unwrap();
+
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 1).await;
+        assert_eq!(batch_indexes(&redelivered), vec![Some(2)]);
+        assert_eq!(payloads(&redelivered), vec![second[2].clone()]);
+        assert_nothing_left(&mut consumer).await;
+
+        consumer.cumulative_ack(&redelivered[0]).await.unwrap();
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_unacked_entry_is_redelivered_after_the_resend_delay() {
+        let topic =
+            BatchedTopic::new("resend", SubType::Shared, BatchAcknowledgment::Tracked).await;
+        let mut consumer: Consumer<TestData, _> = topic
+            .consumer()
+            .with_unacked_message_resend_delay(Some(Duration::from_secs(1)))
+            .build()
+            .await
+            .unwrap();
+        let mut producer = topic.producer(3).await;
+        let published = topic.publish_batch(&mut producer, 0, 3).await;
+
+        let received = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&received), published);
+        for msg in &received[..2] {
+            consumer.ack(msg).await.unwrap();
+        }
+
+        // One message left unacked: the delay expires for the entry and it comes back
+        // whole.
+        let redelivered = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&redelivered), published);
+        for msg in &redelivered {
+            consumer.ack(msg).await.unwrap();
+        }
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn indexed_unacked_tail_is_redelivered_after_the_resend_delay() {
+        let topic = BatchedTopic::new(
+            "indexed_resend",
+            SubType::Exclusive,
+            BatchAcknowledgment::Indexed,
+        )
+        .await;
+        let mut consumer: Consumer<TestData, _> = topic
+            .consumer()
+            .with_unacked_message_resend_delay(Some(Duration::from_secs(1)))
+            .build()
+            .await
+            .unwrap();
+        let mut producer = topic.producer(3).await;
+        let published = topic.publish_batch(&mut producer, 0, 3).await;
+
+        let received = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&received), published);
+        consumer.cumulative_ack(&received[1]).await.unwrap();
+
+        // The last message is left unacked: the delay expires for the entry and only that
+        // message comes back, without resubscribing.
+        let redelivered = receive(&mut consumer, 1).await;
+        assert_eq!(batch_indexes(&redelivered), vec![Some(2)]);
+        assert_eq!(payloads(&redelivered), vec![published[2].clone()]);
+        consumer.ack(&redelivered[0]).await.unwrap();
+        assert_nothing_left(&mut consumer).await;
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn tracked_cumulative_ack_inside_the_first_entry_of_a_ledger() {
+        let topic = BatchedTopic::new(
+            "first_entry",
+            SubType::Exclusive,
+            BatchAcknowledgment::Tracked,
+        )
+        .await;
+        let mut consumer = topic.subscribe().await;
+        let mut producer = topic.producer(3).await;
+        let published = topic.publish_batch(&mut producer, 0, 3).await;
+
+        let received = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&received), published);
+        assert_eq!(
+            received[0].message_id().entry_id,
+            0,
+            "a new topic starts a new ledger, whose first entry is 0"
+        );
+
+        // The preceding position is (ledger, -1), which the broker has to accept as a
+        // cumulative ack of nothing in this ledger.
+        consumer.cumulative_ack(&received[1]).await.unwrap();
+        let mut consumer = topic.resubscribe(consumer).await;
+        let redelivered = receive(&mut consumer, 3).await;
+        assert_eq!(payloads(&redelivered), published);
+
+        consumer.cumulative_ack(&redelivered[2]).await.unwrap();
+        let mut consumer = topic.resubscribe(consumer).await;
+        assert_nothing_left(&mut consumer).await;
     }
 }

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -62,6 +62,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             unacked_message_redelivery_delay,
             options,
             dead_letter_policy,
+            batch_acknowledgment,
         } = config.clone();
         let consumer_id =
             consumer_id.unwrap_or_else(|| CONSUMER_ID_GENERATOR.fetch_add(1, Ordering::SeqCst));
@@ -119,6 +120,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             batch_size,
             unacked_message_redelivery_delay,
             dead_letter_policy.clone(),
+            batch_acknowledgment,
             options.clone(),
         );
         let engine_task = client.executor.spawn(Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub use connection::Authentication;
 pub use connection_manager::{
     BrokerAddress, ConnectionRetryOptions, OperationRetryOptions, TlsOptions,
 };
-pub use consumer::{Consumer, ConsumerBuilder, ConsumerOptions};
+pub use consumer::{BatchAcknowledgment, Consumer, ConsumerBuilder, ConsumerOptions};
 pub use error::Error;
 #[cfg(any(
     feature = "async-std-runtime",

--- a/src/message.rs
+++ b/src/message.rs
@@ -599,6 +599,45 @@ pub mod proto {
         }
     }
 
+    impl MessageIdData {
+        /// Batch index and batch size, when this id names a message inside a batch.
+        pub(crate) fn batch(&self) -> Option<(u32, u32)> {
+            match (self.batch_index, self.batch_size) {
+                (Some(index), Some(size)) if index >= 0 && size > 0 => {
+                    Some((index as u32, size as u32))
+                }
+                _ => None,
+            }
+        }
+
+        /// The id of the entry this message belongs to, with `partition` filled in (`-1` when
+        /// unset, as the broker sends it) so that ids differing only in whether they carry it
+        /// compare equal.
+        pub(crate) fn entry(&self) -> MessageIdData {
+            MessageIdData {
+                ledger_id: self.ledger_id,
+                entry_id: self.entry_id,
+                partition: Some(self.partition.unwrap_or(-1)),
+                ..Default::default()
+            }
+        }
+
+        /// The id of the preceding entry. Below entry 0 this wraps to the `-1` the broker reads
+        /// as the position before the ledger's first entry.
+        pub(crate) fn prev_entry(&self) -> MessageIdData {
+            MessageIdData {
+                entry_id: self.entry_id.wrapping_sub(1),
+                ..self.entry()
+            }
+        }
+
+        /// The entry's position as the broker orders it: `entry_id` is signed there, so a
+        /// ledger's `-1` sorts before its first entry.
+        pub(crate) fn position(&self) -> (u64, i64) {
+            (self.ledger_id, self.entry_id as i64)
+        }
+    }
+
     pub fn client_version() -> String {
         format!("{}-v{}", "pulsar-rs", env!("CARGO_PKG_VERSION"))
     }
@@ -623,7 +662,92 @@ mod tests {
     use bytes::BytesMut;
     use tokio_util::codec::{Decoder, Encoder};
 
-    use crate::message::Codec;
+    use crate::message::{proto::MessageIdData, Codec};
+
+    fn batched_id() -> MessageIdData {
+        MessageIdData {
+            ledger_id: 7,
+            entry_id: 3,
+            partition: Some(2),
+            batch_index: Some(1),
+            batch_size: Some(4),
+            ack_set: vec![0b1101],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn batch_needs_both_index_and_size() {
+        assert_eq!(batched_id().batch(), Some((1, 4)));
+        assert_eq!(batched_id().entry().batch(), None);
+        let index_only = MessageIdData {
+            batch_size: None,
+            ..batched_id()
+        };
+        assert_eq!(index_only.batch(), None);
+        let size_only = MessageIdData {
+            batch_index: None,
+            ..batched_id()
+        };
+        assert_eq!(size_only.batch(), None);
+    }
+
+    #[test]
+    fn entry_keeps_only_the_entry_fields() {
+        assert_eq!(
+            batched_id().entry(),
+            MessageIdData {
+                ledger_id: 7,
+                entry_id: 3,
+                partition: Some(2),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn entry_fills_in_a_missing_partition() {
+        let unpartitioned = MessageIdData {
+            partition: None,
+            ..batched_id()
+        };
+        assert_eq!(unpartitioned.entry().partition, Some(-1));
+        assert_eq!(
+            unpartitioned.entry(),
+            MessageIdData {
+                partition: Some(-1),
+                ..batched_id()
+            }
+            .entry()
+        );
+    }
+
+    #[test]
+    fn prev_entry_wraps_below_the_first_entry() {
+        assert_eq!(
+            batched_id().prev_entry(),
+            MessageIdData {
+                entry_id: 2,
+                ..batched_id().entry()
+            }
+        );
+        let first = MessageIdData {
+            entry_id: 0,
+            ..batched_id()
+        };
+        assert_eq!(first.prev_entry().entry_id, u64::MAX);
+    }
+
+    #[test]
+    fn position_orders_the_wrapped_entry_before_the_first() {
+        assert_eq!(batched_id().position(), (7, 3));
+        let first = MessageIdData {
+            entry_id: 0,
+            ..batched_id()
+        };
+        assert_eq!(first.prev_entry().position(), (7, -1));
+        assert!(first.prev_entry().position() < first.position());
+    }
 
     #[test]
     fn parse_simple_command() {


### PR DESCRIPTION
**feat(consumer): track acknowledgments of batched entries**

Acknowledging one message of a batched entry sends a plain ack of the
entry's `(ledger, entry)` id, which the broker takes as an ack of
_every_ message in the entry, processed or not.

This adds support for `BatchAcknowledgment` following the design of
the Java client. `ConsumerBuilder::with_batch_acknowledgment` selects
how a message inside a batched entry is acknowledged:

- `Entry`, the default, acks the whole entry on the first ack of any of
  its messages, which is the behavior described above and what every
  earlier release did.
- `Tracked` keeps a bitset of unacked indexes per delivered entry and
  acks the entry once every message in it has been acked. This is the
  Java client's behavior with `batchIndexAckEnabled=false`, the default
  before Pulsar 4.1.
- `Indexed` additionally sends the remaining bitset as ack_set with each
  ack, so a broker with `acknowledgmentAtBatchIndexLevelEnabled=true`
  records indexes itself and redelivers only the unacked ones. This is
  the Java client's behavior with `batchIndexAckEnabled=true`.

`Entry` is kept as the default to avoid potentially-breaking changes for
applications. This is because `Tracked` and `Indexed` hold an entry
until it is fully acked, so an application that _never_ (n)acks some
messages will hold back acks for the entries, which can end up hitting
the broker's `maxUnackedMessagesPerConsumer` (and thus dispatch to that
consumer stops).

As a side-effect of this change we end up with better support for
cumulative acknowledgements. Under `Tracked` and `Indexed`:

- a cumulative ack in the middle of an entry acks up to the preceding
  entry (Tracked), or that plus the acked prefix of the entry (Indexed);
- the `ack_set` the broker attaches to a redelivery is honored: the
  messages it reports as acked are skipped and their permits returned;
- redelivery timeouts and negative acks are keyed by entry, as the
  broker redelivers whole entries.

In every mode, a cumulative ack now also stops the redelivery timer of
every entry it covers, which matches the Java client. Previously, only
the acked id was dropped, so the timers of already covered entries
still fired and requested redelivery, which on an `exclusive` or
`failover` subscription makes the broker resend everything in flight.

Closes #345

---

**ci: apply the standalone broker configuration from env**

`bin/pulsar standalone` does not read the PULSAR_PREFIX_* variables, so
none of the settings the workflow passes were actually applied.


