### PR TITLE
fix(auth): advertise supports_auth_refresh and support rotating tokens

### DIFF
--- a/src/authentication/token.rs
+++ b/src/authentication/token.rs
@@ -1,21 +1,108 @@
 //! Token Authenticator
 
-use std::rc::Rc;
+use std::{future::Future, path::PathBuf, pin::Pin};
 
 use async_trait::async_trait;
 
 use crate::{authentication::Authentication, error::AuthenticationError};
 
+/// How a [`TokenAuthentication`] obtains the token bytes for a connection.
+enum TokenSource {
+    /// A fixed token, captured once.
+    Static(Vec<u8>),
+    /// A file re-read every time the broker asks for credentials.
+    File(PathBuf),
+    /// A user-supplied async closure, called every time the broker asks for
+    /// credentials.
+    Supplier(Box<dyn Fn() -> BoxTokenFuture + Send + Sync>),
+}
+
+type BoxTokenFuture =
+    Pin<Box<dyn Future<Output = Result<Vec<u8>, AuthenticationError>> + Send + 'static>>;
+
+/// JWT token authentication.
+///
+/// The broker asks for credentials again whenever the ones it holds expire (a
+/// `CommandAuthChallenge`), and on every reconnection. A [`Static`] token cannot answer
+/// those, so a client using one stops working the moment its token expires — use
+/// [`from_file`] or [`from_supplier`] for credentials that rotate.
+///
+/// [`Static`]: TokenAuthentication::new
+/// [`from_file`]: TokenAuthentication::from_file
+/// [`from_supplier`]: TokenAuthentication::from_supplier
 pub struct TokenAuthentication {
-    token: Vec<u8>,
+    source: TokenSource,
 }
 
 impl TokenAuthentication {
+    /// A fixed token that never changes.
+    ///
+    /// Only appropriate for tokens that outlive the client. For an expiring token, use
+    /// [`TokenAuthentication::from_file`] or [`TokenAuthentication::from_supplier`].
     #[allow(clippy::new_ret_no_self)]
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
-    pub fn new(token: String) -> Rc<dyn Authentication> {
-        Rc::new(TokenAuthentication {
-            token: token.into_bytes(),
+    pub fn new(token: String) -> Box<dyn Authentication> {
+        Box::new(TokenAuthentication {
+            source: TokenSource::Static(token.into_bytes()),
+        })
+    }
+
+    /// A token read from `path`, re-read every time the broker asks for credentials.
+    ///
+    /// This is the provider to use for a Kubernetes projected ServiceAccount token, or
+    /// any other token a sidecar rotates in place: the file is read on each auth
+    /// challenge and each reconnection, so a rotated token is picked up without
+    /// restarting the client. Trailing whitespace is trimmed.
+    ///
+    /// Read errors are reported as [`AuthenticationError::Retriable`], so a token file
+    /// that is briefly absent mid-rotation causes a connection retry rather than a
+    /// fatal error.
+    ///
+    /// ```no_run
+    /// # async fn run() -> Result<(), pulsar::Error> {
+    /// use pulsar::{authentication::token::TokenAuthentication, Pulsar, TokioExecutor};
+    ///
+    /// let client: Pulsar<_> = Pulsar::builder("pulsar://localhost:6650", TokioExecutor)
+    ///     .with_auth_provider(TokenAuthentication::from_file(
+    ///         "/var/run/secrets/pulsar/token",
+    ///     ))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn from_file(path: impl Into<PathBuf>) -> Box<dyn Authentication> {
+        Box::new(TokenAuthentication {
+            source: TokenSource::File(path.into()),
+        })
+    }
+
+    /// A token produced by `supplier`, called every time the broker asks for credentials.
+    ///
+    /// Use this when the token comes from somewhere other than a file — a secrets
+    /// manager, an in-memory cache refreshed elsewhere, a token exchange.
+    ///
+    /// ```no_run
+    /// # async fn run() -> Result<(), pulsar::Error> {
+    /// use pulsar::{authentication::token::TokenAuthentication, Pulsar, TokioExecutor};
+    ///
+    /// let auth = TokenAuthentication::from_supplier(|| async {
+    ///     Ok(fetch_token_from_somewhere().await.into_bytes())
+    /// });
+    /// # async fn fetch_token_from_somewhere() -> String { unimplemented!() }
+    /// # let _ = auth;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
+    pub fn from_supplier<F, Fut>(supplier: F) -> Box<dyn Authentication>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<u8>, AuthenticationError>> + Send + 'static,
+    {
+        Box::new(TokenAuthentication {
+            source: TokenSource::Supplier(Box::new(move || Box::pin(supplier()))),
         })
     }
 }
@@ -34,6 +121,101 @@ impl Authentication for TokenAuthentication {
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn auth_data(&mut self) -> Result<Vec<u8>, AuthenticationError> {
-        Ok(self.token.clone())
+        match &self.source {
+            TokenSource::Static(token) => Ok(token.clone()),
+            TokenSource::File(path) => std::fs::read_to_string(path)
+                .map(|token| token.trim().as_bytes().to_vec())
+                .map_err(|e| {
+                    AuthenticationError::Retriable(format!(
+                        "failed to read token file {}: {e}",
+                        path.display()
+                    ))
+                }),
+            TokenSource::Supplier(supplier) => supplier().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn from_file_picks_up_a_rotated_token() {
+        let dir = std::env::temp_dir().join(format!("pulsar-rs-token-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+
+        // Trailing newline is what a k8s projected token volume looks like.
+        std::fs::write(&path, "first-token\n").unwrap();
+        let mut auth = TokenAuthentication::from_file(&path);
+        assert_eq!(auth.auth_data().await.unwrap(), b"first-token".to_vec());
+
+        // Rotated in place, as kubelet does before the old token expires.
+        std::fs::write(&path, "second-token\n").unwrap();
+        assert_eq!(auth.auth_data().await.unwrap(), b"second-token".to_vec());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn from_file_reports_a_missing_file_as_retriable() {
+        let mut auth = TokenAuthentication::from_file("/nonexistent/pulsar-rs/token");
+        match auth.auth_data().await {
+            Err(AuthenticationError::Retriable(_)) => {}
+            other => panic!("expected a retriable error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn from_supplier_is_called_for_every_request() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut auth = {
+            let calls = calls.clone();
+            TokenAuthentication::from_supplier(move || {
+                let calls = calls.clone();
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(format!("token-{n}").into_bytes())
+                }
+            })
+        };
+
+        assert_eq!(auth.auth_data().await.unwrap(), b"token-0".to_vec());
+        assert_eq!(auth.auth_data().await.unwrap(), b"token-1".to_vec());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn static_token_is_stable() {
+        let mut auth = TokenAuthentication::new("fixed".to_string());
+        assert_eq!(auth.auth_method_name(), "token");
+        assert_eq!(auth.auth_data().await.unwrap(), b"fixed".to_vec());
+        assert_eq!(auth.auth_data().await.unwrap(), b"fixed".to_vec());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -495,12 +495,47 @@ pub struct PulsarBuilder<Exe: Executor> {
 }
 
 impl<Exe: Executor> PulsarBuilder<Exe> {
-    /// Authentication parameters (JWT, Biscuit, etc)
+    /// Fixed authentication parameters (JWT, Biscuit, etc)
+    ///
+    /// These credentials are captured once and replayed unchanged on every auth
+    /// challenge and every reconnection, so they must outlive the client. **For a
+    /// token that expires or rotates, use [`with_auth_provider`] instead** — with a
+    /// fixed token the client stops working when the token expires and cannot recover.
+    ///
+    /// [`TokenAuthentication::from_file`] covers the common case of a token file that
+    /// something else rotates in place, such as a Kubernetes projected ServiceAccount
+    /// token:
+    ///
+    /// ```no_run
+    /// # async fn run() -> Result<(), pulsar::Error> {
+    /// use pulsar::{authentication::token::TokenAuthentication, Pulsar, TokioExecutor};
+    ///
+    /// let client: Pulsar<_> = Pulsar::builder("pulsar://localhost:6650", TokioExecutor)
+    ///     .with_auth_provider(TokenAuthentication::from_file(
+    ///         "/var/run/secrets/pulsar/token",
+    ///     ))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`with_auth_provider`]: PulsarBuilder::with_auth_provider
+    /// [`TokenAuthentication::from_file`]: crate::authentication::token::TokenAuthentication::from_file
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_auth(self, auth: Authentication) -> Self {
         self.with_auth_provider(Box::new(auth))
     }
 
+    /// Authentication provider, consulted every time the broker asks for credentials
+    ///
+    /// Unlike [`with_auth`], the provider is called again on each auth challenge and
+    /// each reconnection, so it can supply credentials that expire and rotate. See
+    /// [`TokenAuthentication::from_file`] and [`TokenAuthentication::from_supplier`].
+    ///
+    /// [`with_auth`]: PulsarBuilder::with_auth
+    /// [`TokenAuthentication::from_file`]: crate::authentication::token::TokenAuthentication::from_file
+    /// [`TokenAuthentication::from_supplier`]: crate::authentication::token::TokenAuthentication::from_supplier
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_auth_provider(
         mut self,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1444,6 +1444,11 @@ pub(crate) mod messages {
         producer::{self, ProducerOptions},
     };
 
+    /// Protocol version advertised to the broker, in `CommandConnect` and in every
+    /// `CommandAuthResponse`. Both must report the same value: the broker feeds the
+    /// one on the auth response back through `doAuthentication`.
+    pub(crate) const PROTOCOL_VERSION: i32 = 12;
+
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn connect(auth: Option<Authentication>, proxy_to_broker_url: Option<String>) -> Message {
         let (auth_method_name, auth_data) = match auth {
@@ -1459,7 +1464,17 @@ pub(crate) mod messages {
                     auth_data,
                     proxy_to_broker_url,
                     client_version: proto::client_version(),
-                    protocol_version: Some(12),
+                    protocol_version: Some(PROTOCOL_VERSION),
+                    feature_flags: Some(proto::FeatureFlags {
+                        // Without this the broker closes the connection outright when
+                        // credentials expire ("client doesn't support auth credentials
+                        // refresh") instead of sending a CommandAuthChallenge, and the
+                        // challenge handling below never runs.
+                        supports_auth_refresh: Some(true),
+                        // Left at their defaults: the client neither parses broker entry
+                        // metadata nor implements partial producers.
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1859,7 +1874,11 @@ pub(crate) mod messages {
                         auth_method_name: Some(auth.name),
                         auth_data: Some(auth.data),
                     }),
-                    ..Default::default()
+                    // The broker reads both of these off the auth response and passes
+                    // them into doAuthentication; omitting them left it defaulting the
+                    // protocol version to 0.
+                    client_version: Some(proto::client_version()),
+                    protocol_version: Some(PROTOCOL_VERSION),
                 }),
                 ..Default::default()
             },
@@ -1993,8 +2012,13 @@ mod tests {
             Ok(())
         }
         async fn auth_data(&mut self) -> Result<Vec<u8>, AuthenticationError> {
-            *self.count.write().await += 1;
-            Ok("test_auth_data".as_bytes().to_vec())
+            let mut count = self.count.write().await;
+            // Hand out a different token on every call, the way a rotating credential
+            // source does. A provider returning a constant here cannot tell a refresh
+            // that re-read its credentials apart from one that replayed a stale token.
+            let token = format!("test_auth_data-{count}");
+            *count += 1;
+            Ok(token.into_bytes())
         }
     }
 
@@ -2060,11 +2084,39 @@ mod tests {
         )
         .await;
 
-        let _ = server_stream.next().await;
+        let connect = server_stream.next().await.unwrap();
         let auth_challenge = server_stream.next().await.unwrap();
 
         assert!(connection.is_ok());
         assert_eq!(*auth_count.read().await, 2);
+
+        // The broker only sends a CommandAuthChallenge to clients that advertise
+        // supports_auth_refresh; without the flag it closes the connection instead.
+        match connect {
+            Ok(Message {
+                command:
+                    BaseCommand {
+                        connect: Some(connect),
+                        ..
+                    },
+                ..
+            }) => {
+                assert_eq!(
+                    connect
+                        .feature_flags
+                        .as_ref()
+                        .and_then(|f| f.supports_auth_refresh),
+                    Some(true),
+                    "CommandConnect must advertise supports_auth_refresh"
+                );
+                assert_eq!(
+                    String::from_utf8(connect.auth_data.unwrap()).unwrap(),
+                    "test_auth_data-0"
+                );
+            }
+            _ => panic!("Unexpected message"),
+        };
+
         match auth_challenge {
             Ok(Message {
                 command:
@@ -2076,19 +2128,75 @@ mod tests {
                                         auth_method_name,
                                         auth_data,
                                     }),
-                                ..
+                                client_version,
+                                protocol_version,
                             }),
                         ..
                     },
                 ..
             }) => {
                 assert_eq!(auth_method_name.unwrap(), "test_auth");
+                // The refreshed credentials, not the ones sent on CommandConnect.
                 assert_eq!(
                     String::from_utf8(auth_data.unwrap()).unwrap(),
-                    "test_auth_data"
+                    "test_auth_data-1"
                 );
+                assert_eq!(protocol_version, Some(super::messages::PROTOCOL_VERSION));
+                assert_eq!(client_version, Some(crate::proto::client_version()));
             }
             _ => panic!("Unexpected message"),
         };
+    }
+
+    #[test]
+    fn connect_advertises_auth_refresh_support() {
+        let msg = super::messages::connect(None, None);
+        let connect = msg.command.connect.expect("expected a CommandConnect");
+
+        assert_eq!(
+            connect
+                .feature_flags
+                .as_ref()
+                .and_then(|f| f.supports_auth_refresh),
+            Some(true),
+            "without this the broker closes the connection when credentials expire \
+             instead of sending a CommandAuthChallenge"
+        );
+        assert_eq!(
+            connect.protocol_version,
+            Some(super::messages::PROTOCOL_VERSION)
+        );
+        // Not implemented by this client; advertising either would change the wire
+        // payload the broker sends us.
+        let flags = connect.feature_flags.unwrap();
+        assert_ne!(flags.supports_broker_entry_metadata, Some(true));
+        assert_ne!(flags.supports_partial_producer, Some(true));
+    }
+
+    #[test]
+    fn auth_response_reports_client_and_protocol_version() {
+        let msg = super::messages::auth_challenge(super::Authentication {
+            name: "token".to_string(),
+            data: b"a-token".to_vec(),
+        });
+        let response = msg
+            .command
+            .auth_response
+            .expect("expected a CommandAuthResponse");
+
+        // The broker reads both of these off the auth response and feeds them back
+        // through doAuthentication.
+        assert_eq!(
+            response.protocol_version,
+            Some(super::messages::PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            response.client_version,
+            Some(crate::proto::client_version())
+        );
+
+        let data = response.response.expect("expected AuthData");
+        assert_eq!(data.auth_method_name.unwrap(), "token");
+        assert_eq!(data.auth_data.unwrap(), b"a-token".to_vec());
     }
 }


### PR DESCRIPTION
Fixes #423.

## Root cause A — the disconnects

`messages::connect` never populated `CommandConnect.feature_flags`. The field exists in
`PulsarApi.proto`, but `grep -rn "feature_flags" src/` returned nothing.

The broker gates auth refresh on exactly that flag — `ServerCnx.refreshAuthenticationCredentials()`:

```java
if (!supportsAuthenticationRefresh()) {
    log.warn("[{}] Closing connection because client doesn't support auth credentials refresh", remoteAddress);
    ctx.close();
    return;
}
... writeAndFlush(Commands.newAuthChallenge(authMethod, brokerData, getRemoteEndpointProtocolVersion()));
```

`supportsAuthenticationRefresh()` is `features != null && features.isSupportsAuthRefresh()`,
and `features` is copied from `CommandConnect.feature_flags` in `handleConnect`. The Java
client sets `setSupportsAuthRefresh(true)` in `Commands.newConnect`; this client did not.

So the broker took the `ctx.close()` branch on every token expiry and never sent a
`CommandAuthChallenge` — which is why the reporter never saw `Received AuthChallenge`
while the Python client did.

Consequence: the entire AuthChallenge path already in `connection.rs` (the `Receiver`
arm, the `auth_challenge_rx` refresh task, `messages::auth_challenge`) was dead code
against a real broker. `connection_auth_challenge_test` passed only because the fake
server sent the challenge unprompted.

## Root cause B — the failure to recover

`with_auth(Authentication { name, data })` wraps a `Vec<u8>` snapshot; its `auth_data()`
returns the same bytes forever, as did `TokenAuthentication`. So even with the challenge
working, the response would carry the expired token — and on reconnection the same stale
token produced a server-side `AuthenticationError`, which `establish_retryable()`
classifies as fatal, wedging the client permanently.

This is why the reporter's custom file-reading provider restored recovery but did not
change the disconnect count: it addressed B, not A.

## Changes

**`src/connection.rs`**
- `messages::connect` advertises `feature_flags.supports_auth_refresh = true`.
  `supports_broker_entry_metadata` and `supports_partial_producer` stay `false`: this
  client implements neither, and advertising them would change the payload the broker
  sends back.
- `messages::auth_challenge` now sets `client_version` and `protocol_version`, which the
  broker reads off the auth response and feeds into `doAuthentication`.
- Added `messages::PROTOCOL_VERSION` so the connect frame and the auth response cannot
  report different versions. The value is unchanged at 12 — bumping it pulls in
  broker-entry-metadata expectations and belongs in its own change.

**`src/authentication/token.rs`** — rewritten around a `TokenSource` enum:
- `from_file(path)` re-reads and trims the token on every request. This is the Kubernetes
  projected ServiceAccount case, where a token is rotated in place before it expires.
  Read errors map to `AuthenticationError::Retriable`, so a file briefly absent
  mid-rotation retries instead of failing hard.
- `from_supplier(f)` for tokens sourced some other way.
- `new()` now returns `Box<dyn Authentication>` instead of `Rc<dyn Authentication>`.
  A signature change, but not a usable break: the `Rc` form is `!Send` and could never be
  passed to `with_auth_provider`, and it had no call sites in the crate or examples.

**`src/client.rs`** — `with_auth` / `with_auth_provider` docs now state which one survives
an expiring token, with a `from_file` example.

## Tests

`TestAuthentication` returned a constant token, which cannot distinguish a refresh that
re-read its credentials from one that replayed a stale token. It now hands out a distinct
token per call, and the test asserts the connect frame carries `test_auth_data-0` while
the challenge response carries `-1`.

Added coverage for the connect feature flag, the auth-response version fields, and the
three `TokenAuthentication` constructors.

**Negative check:** reverting the feature flag and the auth-response version fields makes
exactly the three new/updated tests fail, so none of them are vacuous.

## Verification

Run locally on rustc 1.98.0:

- `cargo test --features tokio-runtime --lib` — **44 passed, 0 failed** (38 before)
- `cargo test --features tokio-runtime --doc` — 20 passed, 0 failed
- `cargo fmt --all --check` — clean
- Both CI clippy feature sets — **0 new findings**

## CI will be red until #427 merges

`master` currently carries 15 pre-existing `useless_borrows_in_formatting` errors under
Rust 1.98.0, unrelated to this change — see #426, fixed by #427. I verified the count is
identical (15) on unmodified `master` and on this branch, with **zero** attributable to
these commits. Merging #427 first and rebasing this PR will make it green.

## Not addressed

Making a server-side `AuthenticationError` retryable at connect time. With the above in
place the reported failure no longer depends on it, and it would delay surfacing a
genuinely bad credential by ~5 minutes of backoff. Flagging it as a maintainer call.

## Not verifiable here

End-to-end confirmation against a live broker — that it logs "Refreshing authentication
credentials" rather than "client doesn't support auth credentials refresh", that the
client logs `Received AuthChallenge`, and that the reporter's 45-minute loop stays up.
That needs a broker issuing short-TTL tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016225V4xL2DjNvgKMDQcu7Y
