### PR TITLE
fix(consumer): keep read-only queries responsive under backpressure

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use futures::{
-    channel::{mpsc, mpsc::UnboundedSender},
-    SinkExt, StreamExt,
+    channel::{mpsc, mpsc::UnboundedSender, oneshot},
+    FutureExt, SinkExt, StreamExt,
 };
 
 use crate::{
@@ -45,6 +45,8 @@ pub struct ConsumerEngine<Exe: Executor> {
     engine_rx: Option<mpsc::UnboundedReceiver<EngineMessage<Exe>>>,
     event_rx: mpsc::UnboundedReceiver<EngineEvent<Exe>>,
     event_tx: UnboundedSender<EngineEvent<Exe>>,
+    connection_rx: mpsc::UnboundedReceiver<oneshot::Sender<Arc<Connection<Exe>>>>,
+    connection_tx: mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>>,
     batch_size: u32,
     remaining_messages: i64,
     unacked_message_redelivery_delay: Option<Duration>,
@@ -72,6 +74,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         options: ConsumerOptions,
     ) -> ConsumerEngine<Exe> {
         let (event_tx, event_rx) = mpsc::unbounded();
+        let (connection_tx, connection_rx) = mpsc::unbounded();
         ConsumerEngine {
             client,
             connection,
@@ -85,6 +88,8 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             engine_rx: Some(engine_rx),
             event_rx,
             event_tx,
+            connection_rx,
+            connection_tx,
             batch_size,
             remaining_messages: batch_size as i64,
             unacked_message_redelivery_delay,
@@ -92,6 +97,12 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             dead_letter_policy,
             options,
         }
+    }
+
+    pub(crate) fn connection_sender(
+        &self,
+    ) -> mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>> {
+        self.connection_tx.clone()
     }
 
     fn register_source<E, M>(&self, mut rx: mpsc::UnboundedReceiver<E>, mapper: M) -> Result<(), ()>
@@ -199,7 +210,19 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 self.remaining_messages = self.batch_size as i64;
             }
 
-            match Self::timeout(self.event_rx.next(), Duration::from_secs(1)).await {
+            let event = Self::timeout(
+                async {
+                    futures::select! {
+                        event = self.event_rx.next().fuse() => event,
+                        sender = self.connection_rx.next().fuse() => sender.map(|sender| {
+                            EngineEvent::EngineMessage(Some(EngineMessage::GetConnection(sender)))
+                        }),
+                    }
+                },
+                Duration::from_secs(1),
+            )
+            .await;
+            match event {
                 Err(_) => {
                     // If you are reading this comment, you may have an issue where you have
                     // received a batched message that is greater that the batch
@@ -264,7 +287,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                     // End of Topic
                     Ok(false) => Some(Ok(())),
                     Err(e) => {
-                        if let Err(e) = self.tx.send(Err(e)).await {
+                        if let Err(e) = self.send_with_connection_requests(Err(e)).await {
                             error!("cannot send a message from the consumer engine to the consumer({}), stopping the engine", self.id);
                             Some(Err(Error::Consumer(e.into())))
                         } else {
@@ -329,12 +352,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 true
             }
             Some(EngineMessage::GetConnection(sender)) => {
-                let _ = sender.send(self.connection.clone()).map_err(|_| {
-                    error!(
-                        "consumer requested the engine's connection but dropped the \
-                                     channel before receiving"
-                    );
-                });
+                Self::respond_connection(&self.connection, sender);
                 true
             }
         }
@@ -608,8 +626,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         payload: Payload,
     ) -> Result<(), Error> {
         let now = Instant::now();
-        self.tx
-            .send(Ok((message_id.clone(), payload)))
+        self.send_with_connection_requests(Ok((message_id.clone(), payload)))
             .await
             .map_err(|e| {
                 error!("tx returned {:?}", e);
@@ -619,6 +636,37 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             self.unacked_messages.insert(message_id, now + duration);
         }
         Ok(())
+    }
+
+    async fn send_with_connection_requests(
+        &mut self,
+        message: Result<(MessageIdData, Payload), Error>,
+    ) -> Result<(), mpsc::SendError> {
+        let send = self.tx.send(message).fuse();
+        futures::pin_mut!(send);
+        loop {
+            futures::select! {
+                result = send => return result,
+                sender = self.connection_rx.next().fuse() => {
+                    match sender {
+                        Some(sender) => Self::respond_connection(&self.connection, sender),
+                        None => return send.await,
+                    }
+                }
+            }
+        }
+    }
+
+    fn respond_connection(
+        connection: &Arc<Connection<Exe>>,
+        sender: oneshot::Sender<Arc<Connection<Exe>>>,
+    ) {
+        let _ = sender.send(connection.clone()).map_err(|_| {
+            error!(
+                "consumer requested the engine's connection but dropped the \
+                                     channel before receiving"
+            );
+        });
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]

--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
 use futures::{
     channel::{mpsc, mpsc::UnboundedSender, oneshot},
+    future::Shared,
     FutureExt, SinkExt, StreamExt,
 };
 
@@ -32,9 +33,16 @@ use crate::{
 const SYSTEM_PROPERTY_REAL_TOPIC: &str = "REAL_TOPIC";
 const SYSTEM_PROPERTY_ORIGIN_MESSAGE_ID: &str = "ORIGIN_MESSAGE_ID";
 
+pub(crate) enum ConnectionSnapshot<Exe: Executor> {
+    Ready(Arc<Connection<Exe>>),
+    Reconnecting(Shared<oneshot::Receiver<Arc<Connection<Exe>>>>),
+    Closed,
+}
+
 pub struct ConsumerEngine<Exe: Executor> {
     client: Pulsar<Exe>,
     connection: Arc<Connection<Exe>>,
+    connection_snapshot: Arc<Mutex<ConnectionSnapshot<Exe>>>,
     topic: String,
     subscription: String,
     sub_type: SubType,
@@ -45,8 +53,6 @@ pub struct ConsumerEngine<Exe: Executor> {
     engine_rx: Option<mpsc::UnboundedReceiver<EngineMessage<Exe>>>,
     event_rx: mpsc::UnboundedReceiver<EngineEvent<Exe>>,
     event_tx: UnboundedSender<EngineEvent<Exe>>,
-    connection_rx: mpsc::UnboundedReceiver<oneshot::Sender<Arc<Connection<Exe>>>>,
-    connection_tx: mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>>,
     batch_size: u32,
     remaining_messages: i64,
     unacked_message_redelivery_delay: Option<Duration>,
@@ -74,9 +80,11 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         options: ConsumerOptions,
     ) -> ConsumerEngine<Exe> {
         let (event_tx, event_rx) = mpsc::unbounded();
-        let (connection_tx, connection_rx) = mpsc::unbounded();
         ConsumerEngine {
             client,
+            connection_snapshot: Arc::new(Mutex::new(ConnectionSnapshot::Ready(
+                connection.clone(),
+            ))),
             connection,
             topic,
             subscription,
@@ -88,8 +96,6 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
             engine_rx: Some(engine_rx),
             event_rx,
             event_tx,
-            connection_rx,
-            connection_tx,
             batch_size,
             remaining_messages: batch_size as i64,
             unacked_message_redelivery_delay,
@@ -99,10 +105,8 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         }
     }
 
-    pub(crate) fn connection_sender(
-        &self,
-    ) -> mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>> {
-        self.connection_tx.clone()
+    pub(crate) fn connection_snapshot(&self) -> Arc<Mutex<ConnectionSnapshot<Exe>>> {
+        self.connection_snapshot.clone()
     }
 
     fn register_source<E, M>(&self, mut rx: mpsc::UnboundedReceiver<E>, mapper: M) -> Result<(), ()>
@@ -210,19 +214,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 self.remaining_messages = self.batch_size as i64;
             }
 
-            let event = Self::timeout(
-                async {
-                    futures::select! {
-                        event = self.event_rx.next().fuse() => event,
-                        sender = self.connection_rx.next().fuse() => sender.map(|sender| {
-                            EngineEvent::EngineMessage(Some(EngineMessage::GetConnection(sender)))
-                        }),
-                    }
-                },
-                Duration::from_secs(1),
-            )
-            .await;
-            match event {
+            match Self::timeout(self.event_rx.next(), Duration::from_secs(1)).await {
                 Err(_) => {
                     // If you are reading this comment, you may have an issue where you have
                     // received a batched message that is greater that the batch
@@ -287,7 +279,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                     // End of Topic
                     Ok(false) => Some(Ok(())),
                     Err(e) => {
-                        if let Err(e) = self.send_with_connection_requests(Err(e)).await {
+                        if let Err(e) = self.tx.send(Err(e)).await {
                             error!("cannot send a message from the consumer engine to the consumer({}), stopping the engine", self.id);
                             Some(Err(Error::Consumer(e.into())))
                         } else {
@@ -352,7 +344,12 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 true
             }
             Some(EngineMessage::GetConnection(sender)) => {
-                Self::respond_connection(&self.connection, sender);
+                let _ = sender.send(self.connection.clone()).map_err(|_| {
+                    error!(
+                        "consumer requested the engine's connection but dropped the \
+                                     channel before receiving"
+                    );
+                });
                 true
             }
         }
@@ -626,7 +623,8 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         payload: Payload,
     ) -> Result<(), Error> {
         let now = Instant::now();
-        self.send_with_connection_requests(Ok((message_id.clone(), payload)))
+        self.tx
+            .send(Ok((message_id.clone(), payload)))
             .await
             .map_err(|e| {
                 error!("tx returned {:?}", e);
@@ -638,42 +636,14 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
         Ok(())
     }
 
-    async fn send_with_connection_requests(
-        &mut self,
-        message: Result<(MessageIdData, Payload), Error>,
-    ) -> Result<(), mpsc::SendError> {
-        let send = self.tx.send(message).fuse();
-        futures::pin_mut!(send);
-        if let std::task::Poll::Ready(result) = futures::poll!(send.as_mut()) {
-            return result;
-        }
-        loop {
-            futures::select! {
-                result = send => return result,
-                sender = self.connection_rx.next().fuse() => {
-                    match sender {
-                        Some(sender) => Self::respond_connection(&self.connection, sender),
-                        None => return send.await,
-                    }
-                }
-            }
-        }
-    }
-
-    fn respond_connection(
-        connection: &Arc<Connection<Exe>>,
-        sender: oneshot::Sender<Arc<Connection<Exe>>>,
-    ) {
-        let _ = sender.send(connection.clone()).map_err(|_| {
-            error!(
-                "consumer requested the engine's connection but dropped the \
-                                     channel before receiving"
-            );
-        });
-    }
-
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     async fn reconnect(&mut self) -> Result<(), Error> {
+        let (sender, receiver) = oneshot::channel();
+        *self
+            .connection_snapshot
+            .lock()
+            .map_err(|_| ConnectionError::Disconnected)? =
+            ConnectionSnapshot::Reconnecting(receiver.shared());
         debug!("reconnecting consumer for topic: {}", self.topic);
 
         // send CloseConsumer to server
@@ -705,7 +675,12 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
 
         self.remaining_messages = self.batch_size as i64;
         self.messages_rx = Some(messages);
-
+        *self
+            .connection_snapshot
+            .lock()
+            .map_err(|_| ConnectionError::Disconnected)? =
+            ConnectionSnapshot::Ready(self.connection.clone());
+        let _ = sender.send(self.connection.clone());
         Ok(())
     }
 
@@ -744,6 +719,14 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
 
 impl<Exe: Executor> std::ops::Drop for ConsumerEngine<Exe> {
     fn drop(&mut self) {
+        let previous = std::mem::replace(
+            &mut *self
+                .connection_snapshot
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            ConnectionSnapshot::Closed,
+        );
+        drop(previous);
         let conn = self.connection.clone();
         let id = self.id;
         let name = self.name.clone();
@@ -771,7 +754,7 @@ mod tests {
     use super::*;
     use crate::{consumer::data::MessageIdDataReceiver, test_utils::new_pulsar, TokioExecutor};
 
-    async fn delivery_engine(
+    async fn snapshot_engine(
         capacity: usize,
     ) -> (ConsumerEngine<TokioExecutor>, MessageIdDataReceiver) {
         let client = new_pulsar().await;
@@ -779,11 +762,12 @@ mod tests {
         let (tx, rx) = mpsc::channel(capacity);
         let (_, messages_rx) = mpsc::unbounded();
         let (_, engine_rx) = mpsc::unbounded();
+        let suffix: u64 = rand::random();
         let engine = ConsumerEngine::new(
             client,
             connection,
-            "delivery-test".into(),
-            "delivery-test".into(),
+            format!("persistent://public/default/connection-snapshot-{suffix}"),
+            format!("snapshot-{suffix}"),
             SubType::Exclusive,
             u64::MAX,
             None,
@@ -798,6 +782,118 @@ mod tests {
         (engine, rx)
     }
 
+    #[tokio::test]
+    async fn engine_drop_invalidates_retained_snapshot() {
+        let (engine, _output) = snapshot_engine(1).await;
+        let snapshot = engine.connection_snapshot();
+        assert!(matches!(
+            &*snapshot.lock().unwrap(),
+            ConnectionSnapshot::Ready(connection) if Arc::ptr_eq(connection, &engine.connection)
+        ));
+        drop(engine);
+        assert!(matches!(
+            *snapshot.lock().unwrap(),
+            ConnectionSnapshot::Closed
+        ));
+    }
+
+    #[tokio::test]
+    async fn aborting_owning_task_invalidates_snapshot() {
+        let (mut engine, _output) = snapshot_engine(1).await;
+        let (commands, receiver) = mpsc::unbounded();
+        engine.engine_rx = Some(receiver);
+        let snapshot = engine.connection_snapshot();
+        let task = tokio::spawn(async move { engine.engine().await });
+        tokio::task::yield_now().await;
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert!(matches!(
+            *snapshot.lock().unwrap(),
+            ConnectionSnapshot::Closed
+        ));
+        drop(commands);
+    }
+
+    #[tokio::test]
+    async fn reconnect_only_publishes_connection_after_subscription_completes() {
+        let (mut engine, _output) = snapshot_engine(1).await;
+        let snapshot = engine.connection_snapshot();
+        let mut response;
+        {
+            let mut reconnect = Box::pin(engine.reconnect());
+            assert!(futures::poll!(reconnect.as_mut()).is_pending());
+            response = match &*snapshot.lock().unwrap() {
+                ConnectionSnapshot::Reconnecting(receiver) => receiver.clone(),
+                _ => panic!("expected reconnecting snapshot"),
+            };
+            drop(response.clone());
+            assert!(futures::poll!(&mut response).is_pending());
+            tokio::time::timeout(Duration::from_secs(10), reconnect)
+                .await
+                .unwrap()
+                .unwrap();
+        }
+        let connection = tokio::time::timeout(Duration::from_secs(1), response)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(Arc::ptr_eq(&connection, &engine.connection));
+        assert!(matches!(
+            &*snapshot.lock().unwrap(),
+            ConnectionSnapshot::Ready(connection) if Arc::ptr_eq(connection, &engine.connection)
+        ));
+    }
+
+    #[tokio::test]
+    async fn canceling_reconnect_cancels_queries() {
+        let (mut engine, _output) = snapshot_engine(1).await;
+        let snapshot = engine.connection_snapshot();
+        let response;
+        {
+            let mut reconnect = Box::pin(engine.reconnect());
+            assert!(futures::poll!(reconnect.as_mut()).is_pending());
+            response = match &*snapshot.lock().unwrap() {
+                ConnectionSnapshot::Reconnecting(receiver) => receiver.clone(),
+                _ => panic!("expected reconnecting snapshot"),
+            };
+        }
+        assert!(tokio::time::timeout(Duration::from_secs(1), response)
+            .await
+            .unwrap()
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn reconnect_failure_cancels_queries_before_error_delivery() {
+        let (mut engine, _output) = snapshot_engine(1).await;
+        engine.topic = "invalid://topic".into();
+        let snapshot = engine.connection_snapshot();
+        let response;
+        {
+            let mut reconnect = Box::pin(engine.reconnect());
+            assert!(futures::poll!(reconnect.as_mut()).is_pending());
+            response = match &*snapshot.lock().unwrap() {
+                ConnectionSnapshot::Reconnecting(receiver) => receiver.clone(),
+                _ => panic!("expected reconnecting snapshot"),
+            };
+            assert!(tokio::time::timeout(Duration::from_secs(10), reconnect)
+                .await
+                .unwrap()
+                .is_err());
+        }
+        assert!(tokio::time::timeout(Duration::from_secs(1), response)
+            .await
+            .unwrap()
+            .is_err());
+        let later_query = match &*snapshot.lock().unwrap() {
+            ConnectionSnapshot::Reconnecting(receiver) => receiver.clone(),
+            _ => panic!("expected failed reconnect snapshot"),
+        };
+        assert!(tokio::time::timeout(Duration::from_secs(1), later_query)
+            .await
+            .unwrap()
+            .is_err());
+    }
     fn message() -> (MessageIdData, Payload) {
         (
             MessageIdData {
@@ -814,34 +910,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_delivery_answers_queries_without_starting_redelivery_timer() {
-        let (mut engine, mut output) = delivery_engine(0).await;
-        let mut queries = engine.connection_sender();
-        let connection = engine.connection.clone();
-        let (id, payload) = message();
-        {
-            let mut send = Box::pin(engine.send_to_consumer(id.clone(), payload));
-            assert!(futures::poll!(send.as_mut()).is_pending());
-            let (resolver, response) = oneshot::channel();
-            queries.send(resolver).await.unwrap();
-            assert!(futures::poll!(send.as_mut()).is_pending());
-            let received_connection = tokio::time::timeout(Duration::from_secs(1), response)
-                .await
-                .unwrap()
-                .unwrap();
-            assert!(Arc::ptr_eq(&connection, &received_connection));
-        }
-        assert!(engine.unacked_messages.is_empty());
-        let (received_id, received_payload) = output.next().await.unwrap().unwrap();
-        assert_eq!(received_id, id);
-        assert_eq!(received_payload.data, b"pending delivery");
-        assert!(output.try_recv().is_err());
-    }
-
-    #[tokio::test]
-    async fn closed_query_channel_preserves_pending_flush_and_timer_timestamp() {
-        let (mut engine, mut output) = delivery_engine(0).await;
-        engine.connection_rx.close();
+    async fn pending_flush_preserves_timer_timestamp() {
+        let (mut engine, mut output) = snapshot_engine(0).await;
         let (id, payload) = message();
         let before_send = Instant::now();
         let after_pending;
@@ -864,7 +934,7 @@ mod tests {
 
     #[tokio::test]
     async fn closed_output_does_not_start_redelivery_timer() {
-        let (mut engine, output) = delivery_engine(0).await;
+        let (mut engine, output) = snapshot_engine(0).await;
         drop(output);
         let (id, payload) = message();
         assert!(engine.send_to_consumer(id, payload).await.is_err());
@@ -873,7 +943,7 @@ mod tests {
 
     #[tokio::test]
     async fn ready_delivery_completes_and_starts_redelivery_timer() {
-        let (mut engine, mut output) = delivery_engine(1).await;
+        let (mut engine, mut output) = snapshot_engine(1).await;
         let (id, payload) = message();
         {
             let mut send = Box::pin(engine.send_to_consumer(id.clone(), payload));

--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -644,6 +644,9 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
     ) -> Result<(), mpsc::SendError> {
         let send = self.tx.send(message).fuse();
         futures::pin_mut!(send);
+        if let std::task::Poll::Ready(result) = futures::poll!(send.as_mut()) {
+            return result;
+        }
         loop {
             futures::select! {
                 result = send => return result,
@@ -753,5 +756,135 @@ impl<Exe: Executor> std::ops::Drop for ConsumerEngine<Exe> {
                 );
             }
         }));
+    }
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    )
+))]
+mod tests {
+    use super::*;
+    use crate::{consumer::data::MessageIdDataReceiver, test_utils::new_pulsar, TokioExecutor};
+
+    async fn delivery_engine(
+        capacity: usize,
+    ) -> (ConsumerEngine<TokioExecutor>, MessageIdDataReceiver) {
+        let client = new_pulsar().await;
+        let connection = client.manager.get_base_connection().await.unwrap();
+        let (tx, rx) = mpsc::channel(capacity);
+        let (_, messages_rx) = mpsc::unbounded();
+        let (_, engine_rx) = mpsc::unbounded();
+        let engine = ConsumerEngine::new(
+            client,
+            connection,
+            "delivery-test".into(),
+            "delivery-test".into(),
+            SubType::Exclusive,
+            u64::MAX,
+            None,
+            tx,
+            messages_rx,
+            engine_rx,
+            1,
+            Some(Duration::from_secs(60)),
+            None,
+            ConsumerOptions::default(),
+        );
+        (engine, rx)
+    }
+
+    fn message() -> (MessageIdData, Payload) {
+        (
+            MessageIdData {
+                ledger_id: 1,
+                entry_id: 2,
+                batch_index: Some(3),
+                ..Default::default()
+            },
+            Payload {
+                metadata: proto::MessageMetadata::default(),
+                data: b"pending delivery".to_vec(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn pending_delivery_answers_queries_without_starting_redelivery_timer() {
+        let (mut engine, mut output) = delivery_engine(0).await;
+        let mut queries = engine.connection_sender();
+        let connection = engine.connection.clone();
+        let (id, payload) = message();
+        {
+            let mut send = Box::pin(engine.send_to_consumer(id.clone(), payload));
+            assert!(futures::poll!(send.as_mut()).is_pending());
+            let (resolver, response) = oneshot::channel();
+            queries.send(resolver).await.unwrap();
+            assert!(futures::poll!(send.as_mut()).is_pending());
+            let received_connection = tokio::time::timeout(Duration::from_secs(1), response)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(Arc::ptr_eq(&connection, &received_connection));
+        }
+        assert!(engine.unacked_messages.is_empty());
+        let (received_id, received_payload) = output.next().await.unwrap().unwrap();
+        assert_eq!(received_id, id);
+        assert_eq!(received_payload.data, b"pending delivery");
+        assert!(output.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn closed_query_channel_preserves_pending_flush_and_timer_timestamp() {
+        let (mut engine, mut output) = delivery_engine(0).await;
+        engine.connection_rx.close();
+        let (id, payload) = message();
+        let before_send = Instant::now();
+        let after_pending;
+        {
+            let mut send = Box::pin(engine.send_to_consumer(id.clone(), payload));
+            assert!(futures::poll!(send.as_mut()).is_pending());
+            after_pending = Instant::now();
+            let (received_id, _) = output.next().await.unwrap().unwrap();
+            assert_eq!(received_id, id);
+            tokio::time::timeout(Duration::from_secs(1), send)
+                .await
+                .unwrap()
+                .unwrap();
+        }
+        let deadline = engine.unacked_messages[&id];
+        assert!(deadline >= before_send + Duration::from_secs(60));
+        assert!(deadline <= after_pending + Duration::from_secs(60));
+        assert_eq!(engine.unacked_messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn closed_output_does_not_start_redelivery_timer() {
+        let (mut engine, output) = delivery_engine(0).await;
+        drop(output);
+        let (id, payload) = message();
+        assert!(engine.send_to_consumer(id, payload).await.is_err());
+        assert!(engine.unacked_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ready_delivery_completes_and_starts_redelivery_timer() {
+        let (mut engine, mut output) = delivery_engine(1).await;
+        let (id, payload) = message();
+        {
+            let mut send = Box::pin(engine.send_to_consumer(id.clone(), payload));
+            assert!(matches!(
+                futures::poll!(send.as_mut()),
+                std::task::Poll::Ready(Ok(()))
+            ));
+        }
+        assert!(engine.unacked_messages.contains_key(&id));
+        let (received_id, received_payload) = output.next().await.unwrap().unwrap();
+        assert_eq!(received_id, id);
+        assert_eq!(received_payload.data, b"pending delivery");
     }
 }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1641,6 +1641,162 @@ mod tests {
             .unwrap()
     }
 
+    async fn backpressured_consumer(
+        client: &Pulsar<TokioExecutor>,
+        topic: &str,
+    ) -> Consumer<Vec<u8>, TokioExecutor> {
+        client
+            .consumer()
+            .with_topic(topic)
+            .with_subscription("backpressure")
+            .with_subscription_type(SubType::Shared)
+            .with_options(
+                ConsumerOptions::default()
+                    .with_receiver_queue_size(1)
+                    .with_initial_position(InitialPosition::Earliest),
+            )
+            .build()
+            .await
+            .unwrap()
+    }
+
+    async fn publish_backpressure_batch(client: &Pulsar<TokioExecutor>, topic: &str) {
+        let mut producer = client
+            .producer()
+            .with_topic(topic)
+            .with_options(producer::ProducerOptions {
+                batch_size: Some(32),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+        let mut receipts = Vec::new();
+        for index in 0..32 {
+            receipts.push(
+                producer
+                    .send_non_blocking(format!("message-{index}"))
+                    .await
+                    .unwrap(),
+            );
+        }
+        timeout(
+            DEFAULT_RECV_TIMEOUT,
+            futures::future::try_join_all(receipts),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        producer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn read_only_queries_progress_with_backpressured_batch() {
+        let client = new_client().await;
+        let topic = format!("backpressured_queries_{}", rand::random::<u64>());
+        let mut consumer = backpressured_consumer(&client, &topic).await;
+        publish_backpressure_batch(&client, &topic).await;
+        let first = recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
+            .await
+            .unwrap();
+
+        timeout(DEFAULT_RECV_TIMEOUT, async {
+            consumer.get_schema(&topic, None).await.unwrap();
+            consumer.check_connection().await.unwrap();
+            assert_eq!(consumer.get_stats().await.unwrap().len(), 1);
+            let last_ids = consumer.get_last_message_id().await.unwrap();
+            assert_eq!(last_ids.len(), 1);
+            assert_eq!(last_ids[0].ledger_id, first.message_id().ledger_id);
+            assert_eq!(last_ids[0].entry_id, first.message_id().entry_id);
+        })
+        .await
+        .expect("read-only queries must progress while batch delivery is paused");
+
+        let mut messages = vec![first];
+        for _ in 1..32 {
+            messages.push(
+                recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
+                    .await
+                    .unwrap(),
+            );
+        }
+        for (index, message) in messages.iter().enumerate() {
+            assert_eq!(message.payload.data, format!("message-{index}").as_bytes());
+            assert_eq!(message.message_id().batch_index, Some(index as i32));
+            assert_eq!(
+                message.message_id().ledger_id,
+                messages[0].message_id().ledger_id
+            );
+            assert_eq!(
+                message.message_id().entry_id,
+                messages[0].message_id().entry_id
+            );
+        }
+        consumer.ack(messages.last().unwrap()).await.unwrap();
+        timeout(DEFAULT_RECV_TIMEOUT, consumer.close())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
+    async fn backpressured_partial_batch_survives_ack_and_reconnect() {
+        let client = new_client().await;
+        let topic = format!("backpressured_ack_{}", rand::random::<u64>());
+        let mut consumer = backpressured_consumer(&client, &topic).await;
+        publish_backpressure_batch(&client, &topic).await;
+        let first = recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(first.message_id().batch_index, Some(0));
+        consumer.ack(&first).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(consumer);
+
+        let mut consumer = backpressured_consumer(&client, &topic).await;
+        for index in 0..32 {
+            let message = recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
+                .await
+                .unwrap();
+            assert_eq!(message.payload.data, format!("message-{index}").as_bytes());
+            assert_eq!(message.message_id().batch_index, Some(index));
+            assert_eq!(message.message_id().ledger_id, first.message_id().ledger_id);
+            assert_eq!(message.message_id().entry_id, first.message_id().entry_id);
+            if index == 31 {
+                consumer.ack(&message).await.unwrap();
+            }
+        }
+        timeout(DEFAULT_RECV_TIMEOUT, consumer.close())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut consumer = backpressured_consumer(&client, &topic).await;
+        timeout(DEFAULT_RECV_TIMEOUT, async {
+            loop {
+                let stats = consumer.get_stats().await.unwrap();
+                assert_eq!(stats.len(), 1);
+                if stats[0].msg_backlog == Some(0) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("acknowledgement must reach the broker before close");
+        consumer.unsubscribe().await.unwrap();
+        consumer.close().await.unwrap();
+    }
+
     // ── schema_version tests ────────────────────────────────────────
 
     #[tokio::test]

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -86,7 +86,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             .await?;
 
         for consumer in self.consumers.values_mut() {
-            consumer.connection().await?.sender().send_ping().await?;
+            consumer.check_connection().await?;
         }
 
         Ok(())

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -86,7 +86,12 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
             .await?;
 
         for consumer in self.consumers.values_mut() {
-            consumer.check_connection().await?;
+            consumer
+                .query_connection()
+                .await?
+                .sender()
+                .send_ping()
+                .await?;
         }
 
         Ok(())

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     task::{Context, Poll},
     time::Duration,
@@ -20,7 +20,7 @@ use crate::{
     consumer::{
         config::ConsumerConfig,
         data::{DeadLetterPolicy, EngineMessage, MessageData, MessageIdDataReceiver},
-        engine::ConsumerEngine,
+        engine::{ConnectionSnapshot, ConsumerEngine},
         message::Message,
     },
     error::{ConnectionError, ConsumerError},
@@ -37,7 +37,7 @@ pub struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
     topic: String,
     messages: Pin<Box<MessageIdDataReceiver>>,
     engine_tx: mpsc::UnboundedSender<EngineMessage<Exe>>,
-    connection_tx: mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>>,
+    connection_snapshot: Arc<Mutex<ConnectionSnapshot<Exe>>>,
     data_type: PhantomData<fn(Payload) -> T::Output>,
     pub(crate) dead_letter_policy: Option<DeadLetterPolicy>,
     pub(super) last_message_received: Option<DateTime<Utc>>,
@@ -122,7 +122,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             dead_letter_policy.clone(),
             options.clone(),
         );
-        let connection_tx = c.connection_sender();
+        let connection_snapshot = c.connection_snapshot();
         let engine_task = client.executor.spawn(Box::pin(async move {
             c.engine()
                 .map(|res| {
@@ -140,7 +140,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             topic,
             messages: Box::pin(rx),
             engine_tx,
-            connection_tx,
+            connection_snapshot,
             data_type: PhantomData,
             dead_letter_policy,
             last_message_received: None,
@@ -168,12 +168,17 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     }
 
     pub(super) async fn query_connection(&mut self) -> Result<Arc<Connection<Exe>>, Error> {
-        let (resolver, response) = oneshot::channel();
-        self.connection_tx
-            .send(resolver)
-            .await
-            .map_err(|_| ConsumerError::Connection(ConnectionError::Disconnected))?;
-
+        let response = {
+            let snapshot = self
+                .connection_snapshot
+                .lock()
+                .map_err(|_| ConnectionError::Disconnected)?;
+            match &*snapshot {
+                ConnectionSnapshot::Ready(connection) => return Ok(connection.clone()),
+                ConnectionSnapshot::Reconnecting(receiver) => receiver.clone(),
+                ConnectionSnapshot::Closed => return Err(ConnectionError::Disconnected.into()),
+            }
+        };
         response.await.map_err(|oneshot::Canceled| {
             error!("the consumer engine dropped the request");
             ConnectionError::Disconnected.into()

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -167,7 +167,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         })
     }
 
-    async fn query_connection(&mut self) -> Result<Arc<Connection<Exe>>, Error> {
+    pub(super) async fn query_connection(&mut self) -> Result<Arc<Connection<Exe>>, Error> {
         let (resolver, response) = oneshot::channel();
         self.connection_tx
             .send(resolver)

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -37,6 +37,7 @@ pub struct TopicConsumer<T: DeserializeMessage, Exe: Executor> {
     topic: String,
     messages: Pin<Box<MessageIdDataReceiver>>,
     engine_tx: mpsc::UnboundedSender<EngineMessage<Exe>>,
+    connection_tx: mpsc::UnboundedSender<oneshot::Sender<Arc<Connection<Exe>>>>,
     data_type: PhantomData<fn(Payload) -> T::Output>,
     pub(crate) dead_letter_policy: Option<DeadLetterPolicy>,
     pub(super) last_message_received: Option<DateTime<Utc>>,
@@ -121,6 +122,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             dead_letter_policy.clone(),
             options.clone(),
         );
+        let connection_tx = c.connection_sender();
         let engine_task = client.executor.spawn(Box::pin(async move {
             c.engine()
                 .map(|res| {
@@ -138,6 +140,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
             topic,
             messages: Box::pin(rx),
             engine_tx,
+            connection_tx,
             data_type: PhantomData,
             dead_letter_policy,
             last_message_received: None,
@@ -164,17 +167,30 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         })
     }
 
+    async fn query_connection(&mut self) -> Result<Arc<Connection<Exe>>, Error> {
+        let (resolver, response) = oneshot::channel();
+        self.connection_tx
+            .send(resolver)
+            .await
+            .map_err(|_| ConsumerError::Connection(ConnectionError::Disconnected))?;
+
+        response.await.map_err(|oneshot::Canceled| {
+            error!("the consumer engine dropped the request");
+            ConnectionError::Disconnected.into()
+        })
+    }
+
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_stats(&mut self) -> Result<CommandConsumerStatsResponse, Error> {
         let consumer_id = self.consumer_id;
-        let conn = self.connection().await?;
+        let conn = self.query_connection().await?;
         let consumer_stats_response = conn.sender().get_consumer_stats(consumer_id).await?;
         Ok(consumer_stats_response)
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn check_connection(&mut self) -> Result<(), Error> {
-        let conn = self.connection().await?;
+        let conn = self.query_connection().await?;
         info!("check connection for id {}", conn.id());
         conn.sender().send_ping().await?;
         Ok(())
@@ -274,7 +290,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub async fn get_last_message_id(&mut self) -> Result<MessageIdData, Error> {
         let consumer_id = self.consumer_id;
-        let conn = self.connection().await?;
+        let conn = self.query_connection().await?;
         let get_last_message_id_response = conn.sender().get_last_message_id(consumer_id).await?;
         Ok(get_last_message_id_response.last_message_id)
     }
@@ -308,7 +324,7 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
         &mut self,
         version: Option<Vec<u8>>,
     ) -> Result<Option<Schema>, Error> {
-        let conn = self.connection().await?;
+        let conn = self.query_connection().await?;
         let schema_response = conn.sender().get_schema(&self.topic, version).await?;
         Ok(schema_response.schema)
     }


### PR DESCRIPTION
Fetching a schema can hang when the consumer’s receive buffer is full: the engine is waiting to deliver messages, while the application needs the schema before it can resume receiving. Stats, connection checks, and last-message-ID queries have the same problem.

This PR lets those read-only queries use the engine’s current connection directly. A short mutex protects the connection state; it is released before any await or network request. Queries during reconnect wait for subscription and flow setup to finish. Failed or cancelled reconnects resolve those waits with an error; dropping the engine closes the shared state.

The delivery and event loops are unchanged from master. Acknowledgements, redelivery, and lifecycle operations keep their existing ordering, including ack-before-close. There are no new tasks, dependencies, or public APIs. A query can still encounter a failed connection before reconnect starts; this PR does not add automatic retries.

### Testing

Ten regression tests cover queries under backpressure, message order, partial-batch replay, ack-before-close, send/flush timing, and connection state during reconnect and shutdown. On Pulsar 2.11.4, all 69 tests and 19 doctests pass; one existing doctest is ignored. Both Clippy configurations pass. Additional Tokio and async-std checks verified all 31 unread batch records survived reconnect and 20 ack-then-close cycles per runtime left no backlog. Local builds used installed protoc instead of `protobuf-src`.

Throughput measurements remain inconclusive. The delivery loop adds no per-message work, but local timings varied widely and the unbatched comparison reversed on a repeat run. These results do not establish performance neutrality.

<details>
<summary>Local throughput measurements</summary>

Release builds, 20,000 records, receive/flow windows of 1,000. Alternating run order; all runs verified exact message order and broker backlog zero. Times below are median receive + ack-enqueue milliseconds, with ranges in parentheses.

| Workload | Runs per version | Master | This PR |
| --- | ---: | ---: | ---: |
| Batches of 100 | 5 | 462 (420–878) | 534 (404–624) |
| Unbatched, initial | 3 | 491 (453–1358) | 1673 (1389–2227) |
| Unbatched, repeat | 5 | 1422 (447–2277) | 461 (379–1692) |

Before the repeat, both binaries were rebuilt with the same harness, lockfile, features, and toolchain; they matched the original binaries byte for byte. The broker ran under amd64 emulation on an arm64 host. This is not a production capacity benchmark.

</details>

Related: #412 addresses backpressure at the connection layer. The acknowledgement work discussed in #175, #428, and #162 remains separate; this PR does not claim to resolve those issues.
