### PR TITLE
fix(consumer): log "rx terminated" at trace level

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -117,7 +117,7 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
                 log::debug!("Error sending close event to channel - {err}");
             }
 
-            log::warn!("rx terminated");
+            log::trace!("rx terminated");
         }))
     }
 


### PR DESCRIPTION
### Motivation

`ConsumerEngine::register_source` spawns a forwarding task per source and logs `rx terminated` at **WARN** when the channel closes. That channel closes on every normal end of a consumer — `Consumer::close()`, `ConsumerEngine::drop()` and `reconnect()` all send `CloseConsumer` — and a `Reader` has no `close()` at all, so being dropped is its only way out. An application that opens one reader per request (an SSE log tail) gets one WARN per client disconnect, with nothing to act on.

The failures that matter are already reported at ERROR right next to it (`Consumer: connection … is not valid`, `could not close consumer`), and #343 demoted the neighbouring "Error sending end event" line for the same reason: *"causing an error log even on normal shutdown with no traffic"*. This line is the other half of that noise.

### Modifications

`log::warn!("rx terminated")` → `log::trace!`, the level of the engine's other lifecycle messages. No behaviour change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.